### PR TITLE
Fix #33:  Use "is" for comparisons, Leave "equals" for isEqualNode()

### DIFF
--- a/sections/ranges.include
+++ b/sections/ranges.include
@@ -368,7 +368,7 @@ interface Range {
 <p>The <dfn><code>deleteContents()</code></dfn>method must run these steps:
 
 <ol>
- <li><p>If <a>start</a> equals <a>end</a>, terminate these steps.
+ <li><p>If <a>start</a> is <a>end</a>, terminate these steps.
  <!-- This might actually make no difference, but it's not immediately
  obvious what would happen otherwise if the start/end were text/comment:
  are all the substeps of the next step actually no-ops, or could some have
@@ -410,7 +410,7 @@ interface Range {
 <ol>
  <li><p>Let <var>fragment</var> be a new <code><a>DocumentFragment</a></code> <a>node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
 
- <li><p>If <var>range</var>'s <a>start</a> equals its <a>end</a>, return <var>fragment</var>.
+ <li><p>If <var>range</var>'s <a>start</a> is its <a>end</a>, return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
  text/comment, to avoid creating an empty clone as the child of the
  fragment. (Opera 11 actually does include such an empty clone, it seems,
@@ -421,7 +421,7 @@ interface Range {
  <li><p>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>'s <a>start node</a>, <a>start offset</a>, <a>end node</a>, and <a>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> equals <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
 
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>original start node</var>.
@@ -554,7 +554,7 @@ interface Range {
 <ol>
  <li><p>Let <var>fragment</var> be a new <code><a>DocumentFragment</a></code> <a >node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
 
- <li><p>If <var>range</var>'s <a>start</a> equals its <a>end</a>, return <var>fragment</var>.
+ <li><p>If <var>range</var>'s <a>start</a> is its <a>end</a>, return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
  text/comment, to avoid creating an empty clone as the child of the
  fragment. (Opera 11 actually does include such an empty clone, it seems,
@@ -565,7 +565,7 @@ interface Range {
  <li><p>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>'s <a>start node</a>, <a>start offset</a>, <a>end node</a>, and <a>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> equals <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
 
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>original start node</var>.
@@ -717,7 +717,7 @@ interface Range {
 
  <li><p>If <var>range</var>'s <a>start node</a> is a <code><a>Text</a></code> <a>node</a>, <a>split</a> it with offset <var>range</var>'s <a>start offset</a>, set <var>referenceNode</var> to the result, and set <var>parent</var> to <var>referenceNode</var>'s <a>parent</a>.
 
- <li><p>If <var>node</var> equals <var>referenceNode</var>, set <var>referenceNode</var> to its <a>next sibling</a>. <!-- Because we're
+ <li><p>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its <a>next sibling</a>. <!-- Because we're
  about to remove node from its parent. -->
 
  <li><p>If <var>node</var>'s <a>parent</a> is not null, <a>remove</a> <var>node</var> from its <a>parent</a>.
@@ -908,7 +908,7 @@ Firefox 12.0a1. -->
 <ol>
  <li><p>Let <var>s</var> be the empty string.
 
- <li><p>If <a>start node</a> equals <a>end node</a>, and it is a <code><a>Text</a></code> <a>node</a>, return the substring of that <code><a>Text</a></code> <a>node</a>'s <a>data</a> beginning at <a>start offset</a> and ending at <a>end offset</a>.
+ <li><p>If <a>start node</a> is <a>end node</a>, and it is a <code><a>Text</a></code> <a>node</a>, return the substring of that <code><a>Text</a></code> <a>node</a>'s <a>data</a> beginning at <a>start offset</a> and ending at <a>end offset</a>.
 
  <li><p>If <a>start node</a> is a <code><a>Text</a></code> <a>node</a>, append to <var>s</var> the substring of that <a>node</a>'s <a>data</a> from the <a>start offset</a> until the end.
 


### PR DESCRIPTION
Use is for comparisons. Leave equals for isEqualNode()