### PR TITLE
Fix #27: base URL is not optional and type of USVString.

### DIFF
--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -824,7 +824,7 @@ interface Node : EventTarget {
   readonly attribute unsigned short nodeType;
   readonly attribute DOMString nodeName;
 
-  readonly attribute DOMString? baseURI;
+  readonly attribute USVString baseURI;
 
   readonly attribute Document? ownerDocument;
   readonly attribute Node? parentNode;
@@ -869,9 +869,10 @@ interface Node : EventTarget {
 
 <p class="note">Note: A <a>node</a>'s <a>node document</a> can be changed by the <a>adopt</a> algorithm.
 
-<p>Each <a>node</a> also has an associated <dfn>base URL</dfn>.
+<p>Each <a>node</a> also has an associated <dfn>document base URL</dfn>.
 
-<p class="note">Note: Other specifications define the value of the <a>base URL</a> and its observable behavior. This specification solely defines the concept and the <code>baseURI</code> attribute.
+<p class="note">Note: Other specifications define the value of the <a>document base URL</a> and its observable behavior. This specification solely defines the concept and the <code>baseURI</code> attribute.
+For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructure.html#document-base-url"> document base URL</a>.
 
 <hr>
 
@@ -1000,10 +1001,10 @@ interface Node : EventTarget {
 
 <dl>
  <dt><code><var>node</var> . baseURI</code>
- <dd><p>Returns the <a>base URL</a>.
+ <dd><p>Returns the <a>document base URL</a>.
 </dl>
 
-<p>The <code>baseURI</code> attribute must return the associated <a>base URL</a>.
+<p>The <code>baseURI</code> attribute must return the associated <a>document base URL</a>.
 
 <hr>
 
@@ -1504,9 +1505,9 @@ interface Node : EventTarget {
  Exposed=Window]
 interface Document : Node {
   [SameObject] readonly attribute DOMImplementation implementation;
-  readonly attribute DOMString URL;
-  readonly attribute DOMString documentURI;
-  readonly attribute DOMString origin;
+  readonly attribute USVString URL;
+  readonly attribute USVString documentURI;
+  readonly attribute USVString origin;
   readonly attribute DOMString compatMode;
   readonly attribute DOMString characterSet;
   readonly attribute DOMString contentType;


### PR DESCRIPTION
Changes in Node & Document.
The attributes related to base URL are not optional and
should be type of USVString instead of DOMString. Use
the normalized name by following the HTML spec.