### PR TITLE
Fix #39: Part I: Always queue mutation records after said mutations.

### DIFF
--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -168,14 +168,10 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
  <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, and a list containing solely <var>node</var> otherwise.
 
  <li>
+ <li><p>If <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, <a href="#node-remove">remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
   <p>If <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, <a>queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>.
 
   <p class="note">Note: This step intentionally does not pay attention to the <i>suppress observers flag</i>.
-
- <li><p>If <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, <a href="#node-remove">remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
-
- <li><p>If <i>suppress observers flag</i> is unset, <a>queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>nodes</var>, nextSibling <var>child</var>, and previousSibling <var>child</var>'s <a href="#tree-previous-sibling">previous sibling</a> or <var>parent</var>'s <a>last child</a> if <var>child</var> is null.
-
  <li>
   <p>For each <var>newNode</var> in <var>nodes</var>, in <a>tree order</a>, run these substeps:
 
@@ -184,6 +180,8 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 
    <li><p>Run the <a>insertion steps</a> with <var>newNode</var>.
   </ol>
+ <li><p>If <i>suppress observers flag</i> is unset, <a>queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>nodes</var>, nextSibling <var>child</var>, and previousSibling <var>child</var>'s <a href="#tree-previous-sibling">previous sibling</a> or <var>parent</var>'s <a>last child</a> if <var>child</var> is null.
+
 </ol>
 
 
@@ -287,11 +285,10 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
  <li><p>If <i>suppress observers flag</i> is unset, <a>queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with removedNodes a list solely containing <var>node</var>, nextSibling <var>node</var>'s <a href="#tree-next-sibling">next sibling</a>,
  and previousSibling <var>oldPreviousSibling</var>.
 
- <li><p>For each <a>ancestor</a> <var>ancestor</var> of <var>node</var>, if <var>ancestor</var> has any <a>registered observers</a> whose <b>options</b>'s <code>subtree</code> is true, then for each such <a>registered observer</a> <var>registered</var>, append a <a>transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>'s list of <a>registered observers</a>.
-
  <li><p>Remove <var>node</var> from its <var>parent</var>.
 
  <li><p>Run the <a>removing steps</a> with <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>.
+ <li><p>For each <a>ancestor</a> <var>ancestor</var> of <var>node</var>, if <var>ancestor</var> has any <a>registered observers</a> whose <b>options</b>'s <code>subtree</code> is true, then for each such <a>registered observer</a> <var>registered</var>, append a <a>transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>'s list of <a>registered observers</a>.
 </ol>
 
 <h4 id="interface-nonelementparentnode">Interface <code><a>NonElementParentNode</a></code></h4>


### PR DESCRIPTION
Queuing of mutation records looks inconsistent. To replace a child with
node within a parent, the mutation record should be queued after the
removal of child and insertion of node.

See https://github.com/whatwg/dom/pull/60 for more details.