### PR TITLE
Fix #36: two changes on Selectors.

### DIFF
--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -371,29 +371,9 @@ Element implements ParentNode;
 
 <p>The <dfn><code>childElementCount</code></dfn> attribute must return the number of <a>children</a> of the <a>context object</a> that are <a>elements</a>.
 
-<p>To <dfn>match a relative selectors string</dfn> <var>relativeSelectors</var> against a <var>set</var>, run these steps:
+<p>The <dfn><code>querySelector(<var>selectors</var>)</code></dfn> method, when invoked, must return the first result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>, and null if the result is an empty list otherwise.
 
-<ol>
- <li><p>Let <var>s</var> be the result of <a href="https://drafts.csswg.org/selectors-4/#parse-relative-selector">parse a relative selector</a> from <var>relativeSelectors</var> against <var>set</var>. [[!SELECTORS4]]
-
- <li><p>If <var>s</var> is failure, <a>throw</a> a "<code><a>SyntaxError</a></code>".
-
- <li><p>Return the result of <a href="https://drafts.csswg.org/selectors4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> using <a href="https://drafts.csswg.org/selectors-4/#scope-element">:scope elements</a> <var>set</var>. [[!SELECTORS4]]
-</ol>
-
-<p>To <dfn>scope-match a selectors string</dfn> <var>selectors</var> against a <var>node</var>, run these steps:
-
-<ol>
- <li><p>Let <var>s</var> be the result of <a href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> <var>selectors</var>. [[!SELECTORS4]]
-
- <li><p>If <var>s</var> is failure, <a>throw</a> a "<code><a>SyntaxError</a></code>".
-
- <li><p>Return the result of <a href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> against <var>node</var>'s <a href="#tree-root">root</a> using <a href="https://drafts.csswg.org/selectors-4/#scoping-root">scoping root</a> <var>node</var> and scoping method <a href="https://drafts.csswg.org/selectors-4/#scoped-selector">scope-filtered</a>. [[!SELECTORS4]].
-</ol>
-
-<p>The <dfn><code>querySelector(<var>selectors</var>)</code></dfn> method must return the first result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>, and null if the result is an empty list otherwise.
-
-<p>The <dfn><code>querySelectorAll(<var>selectors</var>)</code></dfn> method must return the <a>static</a> result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>.
+<p>The <dfn><code>querySelectorAll(<var>selectors</var>)</code></dfn> method, when invoked, must return the <a>static</a> result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>.
 
 <h4 id="interface-nondocumenttypechildnode">Interface <code><a >NonDocumentTypeChildNode</a></code></h4>
 

--- a/sections/terminology.include
+++ b/sections/terminology.include
@@ -121,6 +121,40 @@ return value.
 <var>set</var> and returns the concatenation of the strings in
 <var>set</var>, separated from each other by U+0020.
 
+<h3 id="terminology-selectors">Selectors</h3>
+<!--
+To <dfn export>match a relative selectors string</dfn> <var>relativeSelectors</var>
+against a <var>set</var>, run these steps:
+
+<ol>
+ <li>Let <var>s</var> be the result of
+ <a>parse a relative selector</a> from
+ <var>relativeSelectors</var> against <var>set</var>.
+ [[!SELECTORS4]]
+
+ <li>If <var>s</var> is failure, <a>throw</a> a {{SyntaxError}}.
+
+ <li>Return the result of <a>evaluate a selector</a> <var>s</var>
+  using <a>:scope elements</a> <var>set</var>. [[!SELECTORS4]]
+</ol>
+-->
+
+<p>To <dfn export>scope-match a selectors string</dfn> <var>selectors</var> against a
+<var>node</var>, run these steps:
+
+<ol>
+ <li>Let <var>s</var> be the result of <a>parse a selector</a> <var>selectors</var>.
+ [[!SELECTORS4]]
+
+ <li><p>If <var>s</var> is failure, then <a>throw</a> a {{SyntaxError}}.
+
+ <li><p>Return the result of <a>evaluate a selector</a> <var>s</var> against <var>node</var>'s
+ <a for=tree>root</a> using <a>scoping root</a> <var>node</var>. [[!SELECTORS4]].
+</ol>
+
+<p class=note>Support for namespaces within selectors is not planned and will not be
+added.
+
 <h3 id="terminology-namespaces">Namespaces</h3>
 
 To <dfn export>validate</dfn> a <var>qualifiedName</var>, run these steps:


### PR DESCRIPTION
Changes in Terminology & Node.
1.Group common selectors algorithms to add a note that
  namespaces are not planned.
2.Comment out "match a relative selectors string" since it
  is not being used.