### PR TITLE
Fix #25: adjustments for 'replace a node' in mutation algorithms.

### DIFF
--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -190,29 +190,29 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 <p>To <dfn>replace</dfn> a <var>child</var> with <var>node</var> within a <var>parent</var>, run these steps:
 
 <ol>
- <li><p>If <var>parent</var> is not a <code><a>Document</a></code>, <code><a>DocumentFragment</a></code>, or <code><a>Element</a></code> <a>node</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+ <li><p>If <var>parent</var> is not a {{Document}}, {{DocumentFragment}}, or {{Element}} <a href="#concept-node">node</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li><p>If <var>node</var> is a <a>host-including inclusive ancestor</a> of <var>parent</var>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li><p>If <var>child</var>'s <a>parent</a> is not <var>parent</var>, <a>throw</a> a "<code><a>NotFoundError</a></code>" exception.
 
- <li><p>If <var>node</var> is not a <code><a>DocumentFragment</a></code>, <code><a>DocumentType</a></code>, <code><a>Element</a></code>, <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+ <li><p>If <var>node</var> is not a {{DocumentFragment}}, {{DocumentType}}, {{Element}}, {{Text}}, {{ProcessingInstruction}}, or {{Comment}} <a href="#concept-node">node</a>, <a>throw</a> a "{{HierarchyRequestError}}".
 
- <li><p>If either <var>node</var> is a <code><a>Text</a></code> <a>node</a> and <var>parent</var> is a <a>document</a>, or <var>node</var> is a <a>doctype</a> and <var>parent</var> is not a <a>document</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+ <li><p>If either <var>node</var> is a {{Text}} <a href="#concept-node">node</a> and <var>parent</var> is a <a href="#concept-document">document</a>, or <var>node</var> is a <a href="#concept-doctype">doctype</a> and <var>parent</var> is not a <a href="#concept-document">document</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li>
-  <p>If <var>parent</var> is a <a>document</a>, and any of the statements below, switched on <var>node</var>, are true, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+  <p>If <var>parent</var> is a <a href="#concept-document">document</a>, and any of the statements below, switched on <var>node</var>, are true, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
   <dl class="switch">
-   <dt><code><a>DocumentFragment</a></code> <a>node</a>
+   <dt>{{{DocumentFragment}}} <a href="#concept-node">node</a>
    <dd>
-    <p>If <var>node</var> has more than one <a>element</a> <a>child</a> or has a <code><a>Text</a></code> <a>node</a> <a>child</a>.
+    <p>If <var>node</var> has more than one <a href="#concept-element">element</a> <a>child</a> or has a {{Text}} <a href="#concept-node">node</a> <a>child</a>.
 
-    <p>Otherwise, if <var>node</var> has one <a>element</a> <a>child</a> and either <var>parent</var> has an <a>element</a> <a>child</a> that is not <var>child</var> or a <a>doctype</a> is <a>following</a> <var>child</var>.
+    <p>Otherwise, if <var>node</var> has one <a href="#concept-element">element</a> <a>child</a> and either <var>parent</var> has an <a href="#concept-element">element</a> <a>child</a> that is not <var>child</var> or a <a href="#concept-doctype">doctype</a> is <a>following</a> <var>child</var>.
 
-   <dt><a>element</a> <dd><p><var>parent</var> has an <a>element</a> <a>child</a> that is not <var>child</var> or a <a>doctype</a> is <a>following</a> <var>child</var>.
+   <dt><a href="#concept-element">element</a> <dd><p><var>parent</var> has an <a href="#concept-element">element</a> <a>child</a> that is not <var>child</var> or a <a href="#concept-doctype">doctype</a> is <a>following</a> <var>child</var>.
 
-   <dt><a>doctype</a> <dd><var>parent</var> has a <a>doctype</a> <a>child</a> that is not <var>child</var>, or an <a>element</a> is <a>preceding</a> <var>child</var>.
+   <dt><a href="#concept-doctype">doctype</a> <dd><var>parent</var> has a <a href="#concept-doctype">doctype</a> <a>child</a> that is not <var>child</var>, or an <a href="#concept-element">element</a> is <a>preceding</a> <var>child</var>.
   </dl>
 
   <p class="note">Note: The above statements differ from the <a>pre-insert</a> algorithm.
@@ -221,13 +221,28 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 
  <li><p>If <var>reference child</var> is <var>node</var>, set it to <var>node</var>'s <a href="#tree-next-sibling">next sibling</a>.
 
+ <li><p>Let <var>previousSibling</var> be <var>child</var>'s <a>previous sibling</a>.
+
  <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a>node document</a>.
 
- <li><p><a>Remove</a> <var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set.
+ <li>Let <var>removedNodes</var> be the empty list.
+
+ <li>
+  <p>If <var>child</var>'s <a>parent</a> is not null, run these substeps:
+
+  <ol>
+   <li><p>Set <var>removedNodes</var> to a list solely containing <var>child</var>.
+
+   <li><p><a href="#node-remove">Remove</a> <var>child</var> from its <var>parent</var> with the
+   <i>suppress observers flag</i> set.
+  </ol>
+
+  <p class="note no-backref">The above can only be false if <var>child</var> is <var>node</var>.
+
+ <li>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a
+ {{DocumentFragment}} <a href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise.
 
  <li><p><a href="#node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var> with the <i>suppress observers flag</i> set.
-
- <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, and a list containing solely <var>node</var> otherwise.
 
  <li><p><a>Queue a mutation record</a> of "<code>childList</code>" for target <var>parent</var> with addedNodes <var>nodes</var>, removedNodes a list solely containing <var>child</var>, nextSibling <var>reference child</var>, and previousSibling <var>child</var>'s <a href="#tree-previous-sibling">previous sibling</a>.
 


### PR DESCRIPTION
Several fixes in the procedure of 'replace a node':
1. Do not remove child from its parent when replacing a node by itself
2. Record previous silibing before doing 'adopt a node'.
3. Collect the node's children before doing 'insert a node'.
4. Other formats and reference errors.