### PR TITLE
Fix #40: add getter/setter accessors of Node's attributes.

### DIFF
--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -1037,7 +1037,7 @@ For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructu
  <dd><p>Returns the <a>document base URL</a>.
 </dl>
 
-<p>The <code>baseURI</code> attribute must return the associated <a>document base URL</a>.
+<p>The <code>baseURI</code> attribute's getter must return the associated <a>document base URL</a>.
 
 <hr>
 
@@ -1074,44 +1074,37 @@ For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructu
 
 <div>
 
-<p>The <code>ownerDocument</code> attribute must run these steps:
-<ol>
- <li>If the <a>context object</a> is a <a>document</a>, return null.
+<p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> attribute's getter must return null, if the <a>context object</a> is a <a href="#concept-document">document</a>, and the <a>context object</a>'s
+<a>node document</a> otherwise.
 
- <li>Return the <a>node document</a>.
-</ol>
+<p class="note">The <a>node document</a> of a <a href="#concept-document">document</a> is that <a href="#concept-document">document</a> itself. All <a>nodes</a> have a <a href="#concept-document">document</a> at all times.
 
-<div class="note">
-<p>The <a>node document</a> of a <a>document</a> is that <a>document</a> itself.
-<p>All <a>nodes</a> have a <a>document</a> at all times.
-</div>
+<p>The <dfn><code>parentNode</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent</a>.
 
-<p>The <dfn><code>parentNode</code></dfn> attribute must return the <a>parent</a>.
+<p class="note">An {{Attr}} <a lt="nodes">node</a> has no <a>parent</a>.
 
-<p class="note">An {{Attr}} <a>node</a> has no <a>parent</a>.
-
-<p>The <dfn><code>parentElement</code></dfn> attribute must return the <a>parent element</a>.
+<p>The <dfn><code>parentElement</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent element</a>.
 
 <p>The <dfn><code>hasChildNodes()</code></dfn> method must return true if the <a>context object</a> has <a href="#tree-child">children</a>, and false otherwise.
 
-<p>The <dfn><code>childNodes</code></dfn> attribute must return a <code><a>NodeList</a></code> rooted at the <a>context object</a> matching only <a>children</a>.
+<p>The <dfn><code>childNodes</code></dfn> attribute's getter must return a <code>{{NodeList}}</code> rooted at the <a>context object</a> matching only <a>children</a>.
 
-<p>The <dfn><code>firstChild</code></dfn> attribute must return the <a>first child</a>.
+<p>The <dfn><code>firstChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>first child</a>.
 
-<p>The <dfn><code>lastChild</code></dfn> attribute must return the <a>last child</a>.
+<p>The <dfn><code>lastChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>last child</a>.
 
-<p>The <dfn id="node-previoussibling" for="node"><code>previousSibling</code></dfn> attribute must return the <a href="#tree-previous-sibling">previous sibling</a>.
+<p>The <dfn id="node-previoussibling" for="node"><code>previousSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-previous-sibling">previous sibling</a>.
 
-<p class="note">An {{Attr}} <a>node</a> has no <a>siblings</a>.
+<p class="note">An {{Attr}} <a lt="nodes">node</a> has no <a>siblings</a>.
 
-<p>The <dfn id="node-nextsibling" for="node"><code>nextSibling</code></dfn> attribute must return the <a href="#tree-next-sibling">next sibling</a>.
+<p>The <dfn id="node-nextsibling" for="node"><code>nextSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-next-sibling">next sibling</a>.
 </div>
 
 <hr>
 
 <!-- TODO: domintro -->
 
-<p>The <dfn><code>nodeValue</code></dfn> attribute must return the following, depending on the <a>context object</a>:
+<p>The <dfn><code>nodeValue</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
 
 <dl class="switch">
  <dt><code><a>Attr</a></code>
@@ -1126,7 +1119,7 @@ For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructu
  <dd><p>Null.
 </dl>
 
-<p>The <code><a>nodeValue</a></code> attribute must, on setting, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
+<p>The <code><a>nodeValue</a></code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class="switch">
  <dt><code><a>Attr</a></code>
@@ -1141,7 +1134,7 @@ For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructu
  <dd><p>Do nothing.
 </dl>
 
-<p>The <dfn id="event-textcontent" for="event"><code>textContent</code></dfn> attribute must return the following, depending on the <a>context object</a>:
+<p>The <dfn id="event-textcontent" for="event"><code>textContent</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
 
 <dl class="switch">
  <dt><code><a>DocumentFragment</a></code>
@@ -1160,7 +1153,7 @@ For HTML, see the definition of <a href="https://www.w3.org/TR/html/infrastructu
  <dd><p>Null.
 </dl>
 
-<p>The <code><a href="#event-textcontent">textContent</a></code> attribute must, on setting, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
+<p>The <code><a href="#event-textcontent">textContent</a></code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class="switch">
  <dt><code><a>DocumentFragment</a></code>


### PR DESCRIPTION
Changes in Node.
WebIDL introduces getter/setter, so use the description of
'getter/setter' for the interface Node's attributes.