### PR TITLE
Fix #76: clean up several grammar issues.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,7 +16,7 @@ Status Text: This document is the Second Public Working Draft of an update to th
 </pre>
 
 <pre class="anchors">
-url: https://www.w3.org/TR/WebIDL-1/#idl-DOMException; 
+url: https://www.w3.org/TR/WebIDL-1/#idl-DOMException;
     text: DOMException; type: dfn
     text: IndexSizeError; type: dfn
     text: HierarchyRequestError; type: dfn
@@ -52,12 +52,17 @@ url: https://www.w3.org/TR/WebIDL-1/#idl-DOMException;
     text: NotAllowedError; type: dfn
 urlPrefix: https://www.w3.org/TR/xml/; spec: XML;
     text: xml:space; url: #sec-white-space; type: dfn
-url: https://www.w3.org/TR/xml-names/#NT-QName; type: dfn; spec: xmlns;
-    text: QName
-urlPrefix: https://infra.spec.whatwg.org/#; spec: encoding;
+urlPrefix: https://www.w3.org/TR/xml/#NT-
+    type: type
+        text: Name; url: Name
+        text: Char; url: Char
+urlPrefix: https://www.w3.org/TR/xml-names/#NT-
+    type: type
+        text: QName; url: QName
+urlPrefix: https://infra.spec.whatwg.org/#; spec: infra;
     text: ASCII whitespace; url: ascii-whitespace; type: dfn
     text: ASCII lowercase; url: ascii-lowercase; type: dfn
-urlPrefix: https://www.w3.org/TR/encoding/#; spec: encoding;
+urlPrefix: https://www.w3.org/TR/encoding/#; spec: W3ENCODING;
     text: utf-8; url: utf-8; type: dfn
     text: encoding; url: encoding; type: dfn
 urlPrefix: https://www.w3.org/TR/html51/; spec: HTML51;
@@ -66,22 +71,26 @@ urlPrefix: https://www.w3.org/TR/html51/; spec: HTML51;
     text: HTML parser; url: syntax.html#html-parser; type: dfn
     text: execute a compound microtask subtask; url: webappapis.html#wrap-callbacks; type: dfn
     text: origin; url: browsers.html#concept-cross-origin; type: dfn
-    text: opaque origin; url:browsers.html#opaque-origin; type: dfn
+    text: opaque origin; url: browsers.html#opaque-origin; type: dfn
     text: browsing context; url: browsers.html#browsing-context; type: dfn
     text: unit of related similar-origin browsing contexts; url: browsers.html#unit-of-related-similar-origin-browsing-contexts; type: dfn
     text: Unicode serialization; url: browsers.html#unicode-serialization; type: dfn
     text: HashChangeEvent; url: browsers.html#the-hashchangeevent-interface; type: dfn
     text: template; url: semantics-scripting.html#the-template-element; type: dfn
     text: relevant global object; url: webappapis.html#relevant-global-object; type:dfn
-url: https://heycam.github.io/webidl/#idl-enums; type: dfn;
-    text: unenumerable
-urlPrefix: https://www.w3.org/TR/WebIDL-1/#; spec: WebIDL-1
+    text: Queue; url: webappapis.html#queue-a-microtask; type: dfn
+    text: script; url: semantics-scripting.html#the-script-element; type: dfn
+    text: input; url: sec-forms.html#the-input-element; type: dfn
+    text: document base URL; url: infrastructure.html#document-base-url; type: dfn
+urlPrefix: https://www.w3.org/TR/WebIDL-1/#; spec: WEBIDL1
     text: dictionary member; url: dfn-dictionary-member; type: dfn
     text: identifier; url: dfn-identifier; type: dfn
     text: callback this value; url: dfn-callback-this-value; type: dfn
     text: supported property indices; url: dfn-supported-property-indices; type: dfn
     text: supported property names; url: dfn-supported-property-names; type: dfn
     text: code units; url: dfn-code-unit; type: dfn
+    text: supported property indices; url: dfn-supported-property-indices; type: dfn
+    text: throw; url: dfn-throw; type: dfn
 urlPrefix: https://www.w3.org/TR/uievents/
     text: CompositionEvent; url: #compositionevent; type: dfn
     text: KeyboardEvent; url: #keyboardevent-keyboardevent; type: dfn
@@ -95,6 +104,13 @@ urlPrefix: https://www.w3.org/TR/webstorage/
     text: StorageEvent; url: #storageevent; type: dfn
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Realm; url: realm; type: dfn
+urlPrefix: https://www.w3.org/TR/DOM-Parsing/
+    text: createContextualFragment; url: #widl-Range-createContextualFragment-DocumentFragment-DOMString-fragment; type: dfn
+urlPrefix: https://www.w3.org/TR/cssom-view-1/
+    text: getClientRects; url: #dom-element-getclientrects; type: dfn
+    text: getBoundingClientRect; url: #dom-element-getboundingclientrect; type: dfn
+url: http://software.hixie.ch/utilities/js/live-dom-viewer
+    text: Live DOM Viewer; type: dfn
 </pre>
 
 <style>

--- a/sections/conformance.include
+++ b/sections/conformance.include
@@ -1,5 +1,5 @@
 <section>
-<h2 id="conformance">Conformance</h2>
+<h2 id="conformance-all">Conformance</h2>
 
   All diagrams, examples, and notes in this specification are non-normative, as are all sections explicitly marked non-normative. Everything else in this specification is normative.
 
@@ -34,11 +34,10 @@ out of memory, or to work around platform-specific limitations.
 
   The IDL fragments in this specification must be interpreted as
 required for conforming IDL fragments, as described in the Web IDL
-specification. [[WEBIDL]]
+specification. [[!WEBIDL]]
 
-  Some of the terms used in this specification are defined in
-<a>Encoding</a>, <a>Selectors</a>, <a>Web IDL</a>, <a>XML</a>, and
-<a>Namespaces in XML</a>.[[ENCODING]][[SELECTORS-API]][[WEBIDL]][[XML]][[XML-NAMES]]
+  Some of the terms used in this specification are defined in <a spec=W3ENCODING>Encoding</a>, <cite>Selectors</cite>, <cite>WEBIDL</cite>,
+<cite>XML</cite>, and <cite>Namespaces in XML</cite>.[[!ENCODING]][[!SELECTORS4]][[!WEBIDL]][[!XML]][[!XML-NAMES]]
 
 <h3 id="conformance-extensibility">Extensibility</h3>
 
@@ -49,6 +48,6 @@ allowing only users of specific user agents to access the content in
 question.
 
 When extensions are needed, the DOM Standard can be updated accordingly, or a new standard
-can be written that hooks into the provided extensibility hooks for <dfn lt="applicable specifications|other applicable specifications|applicable specification|other applicable specification">applicable specifications</dfn>.
+can be written that hooks into the provided extensibility hooks for <dfn lt="applicable specifications|other applicable specifications|applicable specification|other applicable specification|specifications">applicable specifications</dfn>.
 
 </section>

--- a/sections/events.include
+++ b/sections/events.include
@@ -14,9 +14,9 @@ function imgFetched(ev) {
 
 <p><a>Event listeners</a> can be removed by utilizing the <code><a>removeEventListener()</a></code> method, passing the same arguments.
 
-<p><a>Events</a> are objects too and implement the <code><a>Event</a></code> interface (or a derived interface). In the example above <var>ev</var> is the <a>event</a>. It is passed as argument to <a>event listener</a>'s <b>callback</b> (typically a JavaScript Function as shown above).
+<p><a>Events</a> are objects too and implement the <code><a>Event</a></code> interface (or a derived interface). In the example above <var ignore>ev</var> is the <a>event</a>. It is passed as argument to <a>event listener</a>'s <b>callback</b> (typically a JavaScript Function as shown above).
 
-<a>Event listeners</a> key off the <a>event</a>'s <code><a>type</a></code> attribute value ("<code>load</code>" in the above example). The <a>event</a>'s <code><a>target</a></code> attribute value returns the object to which the <a>event</a> was <a>dispatched</a> (<var>obj</var> above).
+<a>Event listeners</a> key off the <a>event</a>'s <code>{{Event/type}}</code> attribute value ("<code>load</code>" in the above example). The <a>event</a>'s <code><a>target</a></code> attribute value returns the object to which the <a>event</a> was <a>dispatched</a> (<var ignore>obj</var> above).
 
 <p>Now while typically <a>events</a> are <a>dispatched</a> by the user agent as the result of user interaction or the completion of some task, applications can <a>dispatch</a> <a>events</a> themselves, commonly known as synthetic events:
 
@@ -28,7 +28,7 @@ obj.addEventListener("cat", function(e) { process(e.detail) })
 var event = new CustomEvent("cat", {"detail":{"hazcheeseburger":true}})
 obj.dispatchEvent(event)</code></pre>
 
-<p>Apart from signaling, <a>events</a> are sometimes also used to let an application control what happens next in an operation. For instance as part of form submission an <a>event</a> whose <code><a>type</a></code> attribute value is "<code>submit</code>" is <a>dispatched</a>. If this <a>event</a>'s <code><a>preventDefault()</a></code> method is invoked, form submission will be terminated. Applications who wish to make use of this functionality through <a>events</a> <a>dispatched</a> by the application (synthetic events) can make use of the return value of the <code><a>dispatchEvent()</a></code> method:
+<p>Apart from signaling, <a>events</a> are sometimes also used to let an application control what happens next in an operation. For instance as part of form submission an <a>event</a> whose <code>{{Event/type}}</code> attribute value is "<code>submit</code>" is <a>dispatched</a>. If this <a>event</a>'s <code><a>preventDefault()</a></code> method is invoked, form submission will be terminated. Applications who wish to make use of this functionality through <a>events</a> <a>dispatched</a> by the application (synthetic events) can make use of the return value of the <code><a>dispatchEvent()</a></code> method:
 
 <pre class='example'><code>
 if(obj.dispatchEvent(event)) {
@@ -36,7 +36,7 @@ if(obj.dispatchEvent(event)) {
   …
 }</code></pre>
 
-<p>When an <a>event</a> is <a>dispatched</a> to an object that <a>participates</a> in a <a>tree</a> (e.g. an <a>element</a>), it can reach <a>event listeners</a> on that object's <a>ancestors</a> too. First all object's <a>ancestor</a> <a>event listeners</a> whose <b>capture</b> variable is set to true are invoked, in <a>tree order</a>. Second, object's own <a>event listeners</a> are invoked. And finally, and only if <a>event</a>'s <a>bubbles</a> attribute value is true, object's  <a>ancestor</a> <a>event listeners</a> are invoked again, but now in reverse <a>tree order</a>.
+<p>When an <a>event</a> is <a>dispatched</a> to an object that <a>participates</a> in a <a>tree</a> (e.g. an <a href="#concept-element">element</a>), it can reach <a>event listeners</a> on that object's <a>ancestors</a> too. First all object's <a>ancestor</a> <a>event listeners</a> whose <b>capture</b> variable is set to true are invoked, in <a>tree order</a>. Second, object's own <a>event listeners</a> are invoked. And finally, and only if <a>event</a>'s {{Event/bubbles}} attribute value is true, object's  <a>ancestor</a> <a>event listeners</a> are invoked again, but now in reverse <a>tree order</a>.
 
 <p>Lets look at an example of how <a>events</a> work in a <a>tree</a>:
 
@@ -59,12 +59,13 @@ if(obj.dispatchEvent(event)) {
  &lt;/body&gt;
 &lt;/html&gt;</code></pre>
 
-<p>The <code>debug</code> function will be invoked twice. Each time the <a>event</a>'s <code><a>target</a></code> attribute value will be the <code>span</code> <a>element</a>. The first time <code><a>currentTarget</a></code> attribute's value will be the <a>document</a>, the second time the <code>body</code> <a>element</a>. <code><a>eventPhase</a></code> attribute's value switches from <code><a>CAPTURING_PHASE</a></code> to <code><a>BUBBLING_PHASE</a></code>. If an <a>event listener</a> was registered for the <code>span</code> <a>element</a>, <code><a>eventPhase</a></code> attribute's value would have been <code><a>AT_TARGET</a></code>.
+<p>The <code>debug</code> function will be invoked twice. Each time the <a>event</a>'s <code><a>target</a></code> attribute value will be the <code>span</code> <a href="#concept-element">element</a>. The first time <code>{{Event/currentTarget}}</code> attribute's value will be the <a href="#concept-document">document</a>, the second time the <code>body</code> <a href="#concept-element">element</a>. <code>{{Event/eventPhase}}</code> attribute's value switches from <code>{{Event/CAPTURING_PHASE}}</code> to <code>{{Event/BUBBLING_PHASE}}</code>. If an <a>event listener</a> was registered for the <code>span</code> <a href="#concept-element">element</a>, <code>{{Event/eventPhase}}</code> attribute's value would have been <code>{{Event/AT_TARGET}}</code>.
 
 <h3 id="events-interface-event">Interface <code><a>Event</a></code></h3>
 <pre class='idl'>
 [Constructor(DOMString type, optional EventInit eventInitDict),
  Exposed=(Window,Worker)]
+
 interface Event {
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
@@ -97,80 +98,77 @@ dictionary EventInit {
 };
 </pre>
 
-<p>An <dfn>event</dfn> allows for signaling that
+<p>An {{Event}} object allows for signaling that
 something has occurred. e.g. that an image has completed downloading. It is
 represented by the <code><a>Event</a></code> interface or an interface that
 inherits from the <code><a>Event</a></code> interface.</p>
 
 <dl>
-  : <code><var>event</var> = new <a>Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
-  :: <p>Returns a new <var>event</var> whose <code><a>type</a></code> attribute value is set to <var>type</var>. The optional <var>eventInitDict</var> argument allows for setting the <code><a>bubbles</a></code> and <code><a>cancelable</a></code> attributes via object members of the same name.
+  : <code><var ignore>event</var> = new <a>Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
+  :: <p>Returns a new <var>event</var> whose <code>{{Event/type}}</code> attribute value is set to <var>type</var>. The optional <var>eventInitDict</var> argument allows for setting the <code>{{Event/bubbles}}</code> and <code>{{Event/cancelable}}</code> attributes via object members of the same name.
 
-  : <code><var>event</var> . <a>type</a></code>
+  : <code><var>event</var> . {{Event/type}}</code>
   :: <p>Returns the type of <var>event</var>, e.g. "<code>click</code>", "<code>hashchange</code>", or "<code>submit</code>".
 
-  : <code><var>event</var> . <a>target</a></code>
+  : <code><var>event</var> . {{Event/target}}</code>
   :: <p>Returns the object to which <var>event</var> is <a>dispatched</a>.
 
-  : <code><var>event</var> . <a>currentTarget</a></code>
+  : <code><var>event</var> . {{Event/currentTarget}}</code>
   :: <p>Returns the object whose <a>event listener</a>'s <b>callback</b> is currently being invoked.
 
-  : <code><var>event</var> . <a>eventPhase</a></code>
-  :: <p>Returns the <a>event</a>'s phase, which is one of <code><a>NONE</a></code>, <code title="dom-Event-CAPTURING_PHASE"><a>CAPTURING_PHASE</a></code>, <code><a>AT_TARGET</a></code>, and <code><a>BUBBLING_PHASE</a></code>.
+  : <code><var>event</var> . {{Event/eventPhase}}</code>
+  :: <p>Returns the <a>event</a>'s phase, which is one of <code>{{Event/NONE}}</code>, <code title="dom-Event-CAPTURING_PHASE">{{Event/CAPTURING_PHASE}}</code>, <code>{{Event/AT_TARGET}}</code>, and <code>{{Event/BUBBLING_PHASE}}</code>.
 
-  : <code><var>event</var> . <a>stopPropagation</a>()</code>
+  : <code><var>event</var> . {{Event/stopPropagation()}}</code>
   :: <p>When <a>dispatched</a> in a <a>tree</a>, invoking this method prevents <var>event</var> from reaching any objects other than the current object.
 
-  : <code><var>event</var> . <a>stopImmediatePropagation</a>()</code>
+  : <code><var>event</var> . {{Event/stopImmediatePropagation()}}</code>
   :: <p>Invoking this method prevents <var>event</var> from reaching any registered <a>event listeners</a> after the current one finishes running and, when <a>dispatched</a> in a <a>tree</a>, also prevents <var>event</var> from reaching any other objects.
 
-  : <code><var>event</var> . <a>bubbles</a></code>
+  : <code><var>event</var> . {{Event/bubbles}}</a></code>
   :: <p>Returns true or false depending on how event was initialized. True if <var>event</var> goes through its <code><a>target</a></code> attribute value's <a>ancestors</a> in reverse <a>tree order</a>, and false otherwise.
 
-  : <code><var>event</var> . <a>cancelable</a></code>
+  : <code><var>event</var> . {{Event/cancelable}}</code>
   :: <p>Returns true or false depending on how <var>event</var> was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which <var>event</var> was <a>dispatched</a>, can be canceled by invoking the <code><a>preventDefault()</a></code> method.
 
-  : <code><var>event</var> . <a>preventDefault</a>()</code>
-  :: <p>If invoked when the <code><a>cancelable</a></code> attribute value is true, and while executing a
- listener for the <var>event</var> with {{AddEventListenerOptions/passive}} set to false, signals to the operation that caused <var>event</var> to be <a>dispatched</a> that it needs to be canceled.
+  : <code><var>event</var> . {{Event/preventDefault()}}</code>
+  :: <p>If invoked when the <code>{{Event/cancelable}}</code> attribute value is true, and while executing a listener for the <var>event</var> with {{AddEventListenerOptions/passive}} set to false, signals to the operation that caused <var>event</var> to be <a>dispatched</a> that it needs to be canceled.
 
-  : <code><var>event</var> . <a>defaultPrevented</a></code>
+  : <code><var>event</var> . {{Event/defaultPrevented}}</code>
   :: <p>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancellation, and false otherwise.
 
-  : <code><var>event</var> . <a>isTrusted</a></code>
+  : <code><var>event</var> . {{Event/isTrusted}}</code>
   :: <p>Returns true if <var>event</var> was <a>dispatched</a> by the user agent, and false otherwise.
 
-  : <code><var>event</var> . <a>timeStamp</a></code>
+  : <code><var>event</var> . {{Event/timeStamp}}</code>
   :: <p>Returns the creation time of <var>event</var> as the number of milliseconds that passed since 00:00:00 UTC on 1 January 1970.
 
 </dl>
 
-<p>The <dfn lt="dom event type|event type|type"><code>type</code></dfn> attribute must return the value it was initialized to. When an <a>event</a> is created the attribute must be initialized to the empty string.
+<p>The <dfn attribute for=Event lt="dom event type|event type|type"><code>type</code></dfn> attribute's getter must return the value it was initialized to. When an <a>event</a> is created the attribute must be initialized to the empty string.
 
-<p>The <dfn lt="dom event target|event target|target"><code>target</code></dfn> and <dfn lt="dom event currentTarget|event currentTarget|currentTarget"><code>currentTarget</code></dfn> attributes must return the values they were initialized to. When an <a>event</a> is created the attributes must be initialized to null.
+<p>The <dfn attribute for=Event lt="dom event target|event target|target"><code>target</code></dfn> attribute's getter and <dfn attribute for=Event lt="dom event currentTarget|event currentTarget|currentTarget"><code>currentTarget</code></dfn> attribute's getter must return the values they were initialized to. When an <a>event</a> is created the attributes must be initialized to null.
 
-<p>The <dfn lt="dom event eventPhase|event eventPhase|eventPhase"><code>eventPhase</code></dfn> attribute must return the value it was initialized to, which must be one of the following:</p>
+<p>The <dfn attribute for=Event lt="dom event eventPhase|event eventPhase|eventPhase"><code>eventPhase</code></dfn> attribute's getter must return the value it was initialized to, which must be one of the following:</p>
 <dl>
-  : <dfn lt="dom event NONE|event NONE|NONE"><code>NONE</code></dfn> (numeric value 0)
+  : <dfn const for=Event><code>NONE</code></dfn> (numeric value 0)
   :: <p><a>Events</a> not currently <a>dispatched</a> are in this phase.
 
-  : <dfn lt="dom event capturing_phase|event capturing_phase|capturing_phase"><code>CAPTURING_PHASE</code></dfn> (numeric value 1)</dt>
+  : <dfn const for=Event lt="CAPTURING_PHASE"><code>CAPTURING_PHASE</code></dfn> (numeric value 1)
   :: <p>When an <a>event</a> is <a>dispatched</a> to an object that <a>participates</a> in a <a>tree</a> it will be in this phase before it reaches its <code><a>target</a></code> attribute value.
 
-  : <dfn lt="dom event AT_TARGET|event AT_TARGET|AT_TARGET"><code>AT_TARGET</code></dfn> (numeric value 2)
+  : <dfn const for=Event lt="AT_TARGET"><code>AT_TARGET</code></dfn> (numeric value 2)
   :: <p>When an <a>event</a> is <a>dispatched</a> it will be in this phase on its <code><a>target</a></code> attribute value.
 
-  : <dfn lt="dom event BUBBLING_PHASE|event BUBBLING_PHASE|BUBBLING_PHASE"><code>BUBBLING_PHASE</code></dfn> (numeric value 3)
+  : <dfn const for=Event lt="BUBBLING_PHASE"><code>BUBBLING_PHASE</code></dfn> (numeric value 3)
   :: <p>When an <a>event</a> is <a>dispatched</a> to an object that <a>participates</a> in a <a>tree</a> it will be in this phase after it reaches its <code><a>target</a></code> attribute value.
 
   </dl>
-<p>Initially the attribute must be initialized to
-<code><a>NONE</a></code>.
+<p>Initially the attribute must be initialized to <code>{{Event/NONE}}</code>.
 
 <hr>
 
-<p>Each <a>event</a> has the following associated
-flags that are all initially unset:</p>
+<p>Each <a>event</a> has the following associated flags that are all initially unset:</p>
 <ul>
  <li><dfn>stop propagation flag</dfn>
  <li><dfn>stop immediate propagation flag</dfn>
@@ -180,7 +178,7 @@ flags that are all initially unset:</p>
  <li><dfn>dispatch flag</dfn>
 </ul>
 
-<p>The <dfn attribute for=Event><code>stopPropagation()</code></dfn> method, when invoked, must set the <a>context object</a>'s <a>stop propagation flag</a>.
+<p>The <dfn method for=Event><code>stopPropagation()</code></dfn> method, when invoked, must set the <a>context object</a>'s <a>stop propagation flag</a>.
 
 <p>The <dfn attribute for=Event><code>cancelBubble</code></dfn> attribute's getter must return true
 if <a>context object</a>'s <a>stop propagation flag</a> is set, and false otherwise.
@@ -188,11 +186,11 @@ if <a>context object</a>'s <a>stop propagation flag</a> is set, and false otherw
 <p>The {{Event/cancelBubble}} attribute's setter must set <a>context object</a>'s
 <a>stop propagation flag</a> if the given value is true, and do nothing otherwise.
 
-<p>The <dfn><code>stopImmediatePropagation()</code></dfn> method must set both the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.
+<p>The <dfn method for=Event><code>stopImmediatePropagation()</code></dfn> method must set both the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.
 
-<p>The <dfn lt="dom event bubble|event bubble|bubble|dom event bubbles|event bubbles|bubbles"><code>bubbles</code></dfn> and <dfn lt="dom event cancelable|event cancelable|cancelable"><code>cancelable</code></dfn> attributes must return the values they were initialized to.
+<p>The <dfn attribute for=Event lt="dom event bubble|event bubble|bubble|dom event bubbles|event bubbles|bubbles"><code>bubbles</code></dfn> and <dfn attribute for=Event lt="dom event cancelable|event cancelable|cancelable"><code>cancelable</code></dfn> attributes must return the values they were initialized to.
 
-<p>The <dfn><code>preventDefault()</code></dfn> method, when invoked, must set the
+<p>The <dfn method for=Event><code>preventDefault()</code></dfn> method, when invoked, must set the
 <a>canceled flag</a> if the {{Event/cancelable}} attribute value is true and the
 <a>in passive listener flag</a> is unset.
 
@@ -200,18 +198,18 @@ if <a>context object</a>'s <a>stop propagation flag</a> is set, and false otherw
 has no effect. User agents are encouraged to log the precise cause in a developer console, to aid
 debugging.
 
-<p>The <dfn lt="dom event defaultPrevented|event defaultPrevented|defaultPrevented"><code>defaultPrevented</code></dfn> attribute must return true if the <a>canceled flag</a> is set and false otherwise.
+<p>The <dfn attribute for=Event lt="dom event defaultPrevented|event defaultPrevented|defaultPrevented"><code>defaultPrevented</code></dfn> attribute must return true if the <a>canceled flag</a> is set and false otherwise.
 
 <hr>
 
-<p>The <dfn lt="dom event isTrusted|event isTrusted|isTrusted"><code>isTrusted</code></dfn> attribute must return the value it was initialized to. When an <a>event</a> is created the attribute must be
+<p>The <dfn attribute for=Event lt="dom event isTrusted|event isTrusted|isTrusted"><code>isTrusted</code></dfn> attribute's getter must return the value it was initialized to. When an <a>event</a> is created the attribute must be
 initialized to false.
 
-<p class="note">Note: <code><a>isTrusted</a></code> is a convenience that indicates whether an <a>event</a> is <a>dispatched</a> by the user agent
+<p class="note">Note: <code>{{Event/isTrusted}}</code> is a convenience that indicates whether an <a>event</a> is <a>dispatched</a> by the user agent
 (as opposed to using <code><a>dispatchEvent()</a></code>). The sole legacy exception is {{HTMLElement/click()}}, which causes
-the user agent to dispatch an <a>event</a> whose <code><a>isTrusted</a></code> attribute is initialized to false.
+the user agent to dispatch an <a>event</a> whose <code>{{Event/isTrusted}}</code> attribute is initialized to false.
 
-<p>The <dfn lt="dom event timeStamp|event timeStamp|timeStamp"><code>timeStamp</code></dfn> attribute must return the value it was initialized to. When an <a>event</a> is created the attribute must be initialized to the number of milliseconds that have passed since 00:00:00 UTC on 1 January 1970, ignoring leap seconds.
+<p>The <dfn attribute for=Event lt="dom event timeStamp|event timeStamp|timeStamp"><code>timeStamp</code></dfn> attribute's getter must return the value it was initialized to. When an <a>event</a> is created the attribute must be initialized to the number of milliseconds that have passed since 00:00:00 UTC on 1 January 1970, ignoring leap seconds.
 <!-- leap seconds are ignored by JavaScript too -->
 
 <hr>
@@ -221,16 +219,16 @@ the user agent to dispatch an <a>event</a> whose <code><a>isTrusted</a></code> a
 <ol>
   1. Set the <a>initialized flag</a>.
   2. Unset the <a>stop propagation flag</a>, <a>stop immediate propagation flag</a>, and <a>canceled flag</a>.
-  3. Set the <code><a>isTrusted</a></code> attribute to false.
+  3. Set the <code>{{Event/isTrusted}}</code> attribute to false.
   4. Set the <code><a>target</a></code> attribute to null.
-  5. Set the <code><a>type</a></code> attribute to <var>type</var>.
-  6. Set the <code><a>bubbles</a></code> attribute to <var>bubbles</var>.
-  7. Set the <code><a>cancelable</a></code> attribute to <var>cancelable</var>.
+  5. Set the <code>{{Event/type}}</code> attribute to <var>type</var>.
+  6. Set the <code>{{Event/bubbles}}</code> attribute to <var>bubbles</var>.
+  7. Set the <code>{{Event/cancelable}}</code> attribute to <var>cancelable</var>.
 
 </ol>
 
 <p>The
-<dfn><code>initEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>)</code></dfn>
+<dfn method for=Event><code>initEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
@@ -242,7 +240,7 @@ method, when invoked, must run these steps:
 
 <p class="note">Note: As <a>events</a> have constructors <code><a>initEvent()</a></code> is superfluous. However, it has to be supported for legacy content.
 
-<h3 id="events-interface-customevent">Interface <code><a>CustomEvent</a></code></h3>
+<h3 id="events-interface-customevent">Interface <code>{{CustomEvent}}</code></h3>
 
 <pre class="idl">
 [Constructor(DOMString type, optional CustomEventInit eventInitDict),
@@ -258,30 +256,30 @@ dictionary CustomEventInit : EventInit {
 };
 </pre>
 
-<p><a>Events</a> using the <code><a>CustomEvent</a></code> interface can be used to carry custom data.</p>
+<p><a>Events</a> using the <code>{{CustomEvent}}</code> interface can be used to carry custom data.</p>
 
 <dl class="domintro">
-  : <code><var>event</var> = new <a>CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
+  : <code><var>event</var> = new <a constructor lt="CustomEvent()">CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
   :: <p>Works analogously to the constructor for <code><a>Event</a></code> except that the optional <var>eventInitDict</var> argument now allows for setting the <code title="dom-Event-detail">detail</code> attribute too.
 
-  : <code><var>event</var> . <a>detail</a></code>
+  : <code><var>event</var> . {{CustomEvent/detail}}</code>
   :: <p>Returns any custom data <var>event</var> was created with. Typically used for synthetic events.
 
 </dl>
 
-<p>The <dfn lt="dom event customevent detail|event customevent detail|customevent detail|detail"><code>detail</code></dfn> attribute
+<p>The <dfn attribute for=CustomEvent lt="dom event customevent detail|event customevent detail|customevent detail|detail"><code>detail</code></dfn> attribute
 must return the value it was initialized to.
 
 <p>The
-<dfn><code>initCustomEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>, <var>detail</var>)</code></dfn>
-method must, when invoked, run these steps:
+<dfn method for=CustomEvent><code>initCustomEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>, <var>detail</var>)</code></dfn>
+method, when invoked, must run these steps:
 
 <ol>
   <li>If <a>context object</a>'s <a>dispatch flag</a> is set, terminate these steps.
 
   <li><a>Initialize</a> the <a>context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>.
 
-  <li>Set <a>context object</a>'s <code><a>detail</a></code> attribute to <var>detail</var>.
+  <li>Set <a>context object</a>'s <code>{{CustomEvent/detail}}</code> attribute to <var>detail</var>.
 
 </ol>
 
@@ -294,7 +292,7 @@ method must, when invoked, run these steps:
 
   <li><p> Set its <a>initialized flag</a>.
 
-  <li><p> Initialize the <code><a>type</a></code> attribute to the <var>type</var> argument.
+  <li><p> Initialize the <code>{{Event/type}}</code> attribute to the <var>type</var> argument.
 
   <li><p> If there is an <var>eventInitDict</var> argument then for each <a>dictionary member</a> present, find the attribute on <a>event</a> whose <a>identifier</a> matches the key of the <a>dictionary member</a> and then set the attribute to the value of that <a>dictionary member</a>.
 
@@ -332,9 +330,9 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
 In general, when defining a new interface that inherits from <code><a>Event</a></code> please always ask feedback from the WHATWG or the
 W3C www-dom@w3.org mailing list.
 
-The <code><a>CustomEvent</a></code> interface can be used as starting point. However, do not introduce any <code>init<var>*</var>Event()</code> methods as they are redundant with constructors. Interfaces that inherit from the <code><a>Event</a></code> interface that have such a method only have it for historical reasons.
+The <code>{{CustomEvent}}</code> interface can be used as starting point. However, do not introduce any <code>init<var ignore>*</var>Event()</code> methods as they are redundant with constructors. Interfaces that inherit from the <code><a>Event</a></code> interface that have such a method only have it for historical reasons.
 
-<h3 id="events-interface-eventtarget">Interface <code><a>EventTarget</a></code></h3>
+<h3 id="events-interface-eventtarget">Interface <code>{{EventTarget}}</code></h3>
 
 <pre class="idl">
 [Exposed=(Window,Worker)]
@@ -370,7 +368,7 @@ when something has occurred.
 
 <ul class="brief">
  <li><dfn id="event-listener-type">type</dfn> (a string)
- <li><dfn id="event-listener-callback">callback</dfn> (an {{EventListener}})
+ <li><dfn id="event-listener-callback" for=EventListener>callback</dfn> (an {{EventListener}})
  <li><dfn id="event-listener-capture">capture</dfn> (a boolean, initially false)
  <li><dfn id="event-listener-passive">passive</dfn> (a boolean, initially false)
  <li><dfn id="event-listener-once">once</dfn> (a boolean, initially false)
@@ -384,7 +382,7 @@ fields above, an <a>event listener</a> is a broader concept.
 which takes an <a>event</a> <var>event</var>, and returns an {{EventTarget}} object. Unless
 specified otherwise it returns null.
 
-<p class="note no-backref"><a>Nodes</a> and <a>documents</a> override the <a>get the parent</a> algorithm.
+<p class="note no-backref"><a>Nodes</a> and <a href="#concept-document">documents</a> override the <a>get the parent</a> algorithm.
 
 <p>Each {{EventTarget}} object can have an associated
 <dfn export for=EventTarget>activation behavior</dfn> algorithm. The
@@ -436,7 +434,7 @@ are not to be used for anything else. [[!HTML51]]
   <dd>Remove the <a>event listener</a> in <var>target</var>'s list of <a>event listeners</a> with the same <var>type</var>, <var>callback</var>, and <var>options</var>.
 
   <dt><code><var>target</var> . <a method for=EventTarget lt=dispatchEvent()>dispatchEvent</a>(<var>event</var>)</code>
-  <dd><a>Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns true if either <var>event</var>'s <code><a>cancelable</a></code> attribute value is false or its <code><a>preventDefault()</a></code> method was not invoked, and false otherwise.
+  <dd><a>Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns true if either <var>event</var>'s <code>{{Event/cancelable}}</code> attribute value is false or its <code><a>preventDefault()</a></code> method was not invoked, and false otherwise.
 </dl>
 
 
@@ -470,7 +468,7 @@ steps:
 </ol>
 
 <p>The
-<dfn><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
+<dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
 <ol>
  <li><p>If <var>callback</var> is null, then return.
@@ -486,7 +484,7 @@ method, when invoked, must run these steps:
 </ol>
 
 <p>The
-<dfn><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn> method, when invoked, must run these steps:
+<dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn> method, when invoked, must run these steps:
 <ol>
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
@@ -495,10 +493,10 @@ method, when invoked, must run these steps:
  the associated list of <a>event listeners</a>.
 </ol>
 
-<p>The <dfn><code>dispatchEvent(<var>event</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when invoked, must run these steps:
 <ol>
   <li><p>If <var>event</var>'s <a>dispatch flag</a> is set, or if its <a>initialized flag</a> is not set, <a>throw</a> an "<code>InvalidStateError</code>" exception.[[!WEBIDL]]
-  <li><p>Initialize <var>event</var>'s <code><a>isTrusted</a></code> attribute to false.
+  <li><p>Initialize <var>event</var>'s <code>{{Event/isTrusted}}</code> attribute to false.
   <li><p><a>Dispatch</a> the <var>event</var> and return the value that returns.
 
 </ol>
@@ -515,9 +513,9 @@ that even empty listeners can have a dramatic performance impact on the behavior
 For example, touch and wheel events which can be used to block asynchronous scrolling. In some cases
 this problem can be mitigated by specifying the event to be {{Event/cancelable}} only when there is
 at least one non-{{AddEventListenerOptions/passive}} listener. For example,
-non-{{AddEventListenerOptions/passive}} {{TouchEvent}} listeners must block scrolling, but if all
+non-{{AddEventListenerOptions/passive}} <a>TouchEvent</a> listeners must block scrolling, but if all
 listeners are {{AddEventListenerOptions/passive}} then scrolling can be allowed to start
-<a>in parallel</a> by making the {{TouchEvent}} uncancelable (so that calls to
+<a>in parallel</a> by making the <a>TouchEvent</a> uncancelable (so that calls to
 {{Event/preventDefault()}} are ignored). So code dispatching an event is able to observe the absence
 of non-{{AddEventListenerOptions/passive}} listeners, and use that to clear the {{Event/cancelable}}
 property of the event being dispatched.
@@ -543,7 +541,7 @@ for discussion).
   <li><p>Let <var>activationTarget</var> be <var>target</var>, if <var>isActivationEvent</var> is
   true and <var>target</var> has <a for=EventTarget>activation behavior</a>, and null otherwise.
 
-  <li>Initialize <var>event</var>'s <code><a>eventPhase</a></code> attribute to <code><a>CAPTURING_PHASE</a></code>.
+  <li>Initialize <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute to <code>{{Event/CAPTURING_PHASE}}</code>.
 
   <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
   <a for=EventTarget>legacy-pre-activation behavior</a>, then run <var>activationTarget</var>'s
@@ -551,16 +549,16 @@ for discussion).
 
   <li>For each object in <var>event path</var>, <a>invoke</a> its <a>event listeners</a> with event <var>event</var>, as long as <var>event</var>'s <a>stop propagation flag</a> is unset.
 
-  <li>Initialize <var>event</var>'s <code><a>eventPhase</a></code> attribute to <code><a>AT_TARGET</a></code>.
+  <li>Initialize <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute to <code>{{Event/AT_TARGET}}</code>.
 
   <li><a>Invoke</a> the <a>event listeners</a> of <var>event</var>'s <code><a>target</a></code> attribute value with <var>event</var>, if <var>event</var>'s <a>stop propagation flag</a> is unset.
 
-  <li>If <var>event</var>'s <code><a>bubbles</a></code> attribute value is true, run these substeps:
+  <li>If <var>event</var>'s <code>{{Event/bubbles}}</code> attribute value is true, run these substeps:
 
   <ol>
     1. Reverse the order of <var>event path</var>.
 
-    2. Initialize <var>event</var>'s <code><a>eventPhase</a></code> attribute to <code><a>BUBBLING_PHASE</a></code>.
+    2. Initialize <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute to <code>{{Event/BUBBLING_PHASE}}</code>.
 
     3. For each object in <var>event path</var>, <a>invoke</a> its <a>event listeners</a>, with event <var>event</var> as long as <var>event</var>'s <a>stop propagation flag</a> is unset.
 
@@ -568,9 +566,9 @@ for discussion).
 
   <li>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and <a>stop immediate propagation flag</a>.
 
-  <li>Set <var>event</var>'s <code><a>eventPhase</a></code> attribute to <code><a>NONE</a></code>.
+  <li>Set <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute to <code>{{Event/NONE}}</code>.
 
-  <li>Set <var>event</var>'s <code><a>currentTarget</a></code> attribute to null.
+  <li>Set <var>event</var>'s <code>{{Event/currentTarget}}</code> attribute to null.
 
   <li>
    <p>If <var>activationTarget</var> is non-null, then:
@@ -589,21 +587,21 @@ for discussion).
 </ol>
 
 
-<p>To <dfn lt="listener invoke|event listener invoke|invoke|invokes|invoked">invoke</dfn> an <var> object</var> with <var>event</var> and optional legacyOutputDidListenersThrowFlag, run these steps:</p>
+<p>To <dfn lt="listener invoke|event listener invoke|invoke|invokes|invoked">invoke</dfn> an <var>object</var> with <var>event</var> and optional legacyOutputDidListenersThrowFlag, run these steps:</p>
 <ol>
   <li><p>If <var>event</var>'s <a>stop propagation flag</a> is set, then return.
   <li>Let <var>listeners</var> be a copy of the <a>event listeners</a> associated with the <var>object</var>.
-  <li>Initialize <var>event</var>'s <code><a>currentTarget</a></code> attribute to the <var>object</var>.
+  <li>Initialize <var>event</var>'s <code>{{Event/currentTarget}}</code> attribute to the <var>object</var>.
   <li>For each <a>event listener</a> in <var>listeners</var>, whose <a href="#event-listener-removed">removed</a> is false:
 
   <ol>
    <li><p>Let <var>listener</var> be the <a>event listener</a>.
-   <li><p>If <var>event</var>'s <code><a>type</a></code> attribute value is not <var>listener</var>'s <b>type</b>, terminate these substeps (and run them for the next <a>event listener</a>).
-   <li><p>If <var>event</var>'s <code><a>eventPhase</a></code> attribute value is <code><a>CAPTURING_PHASE</a></code> and <var>listener</var>'s <b>capture</b> is false, terminate these substeps (and run them for the next <a>event listener</a>).
-   <li><p>If <var>event</var>'s <code><a>eventPhase</a></code> attribute value is <code><a>BUBBLING_PHASE</a></code> and <var>listener</var>'s <b>capture</b> is true, terminate these substeps (and run them for the next <a>event listener</a>).
+   <li><p>If <var>event</var>'s <code>{{Event/type}}</code> attribute value is not <var>listener</var>'s <b>type</b>, terminate these substeps (and run them for the next <a>event listener</a>).
+   <li><p>If <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute value is <code>{{Event/CAPTURING_PHASE}}</code> and <var>listener</var>'s <b>capture</b> is false, terminate these substeps (and run them for the next <a>event listener</a>).
+   <li><p>If <var>event</var>'s <code>{{Event/eventPhase}}</code> attribute value is <code>{{Event/BUBBLING_PHASE}}</code> and <var>listener</var>'s <b>capture</b> is true, terminate these substeps (and run them for the next <a>event listener</a>).
    <li><p>If <var>listener</var>'s <a href="#event-listener-once">once</a> is true, then remove <var>listener</var> from    <var>object</var>'s associated list of <a>event listeners</a>.
    <li><p>If <var>listener</var>'s <a href="#event-listener-passive">passive</a> is true, then set <var>event</var>'s <a>in passive listener flag</a>.
-   <li><p>Call <var>listener</var>'s <b>callback</b>'s <code>handleEvent</code>, with the event passed to this algorithm as the first argument and <var>event</var>'s <code><a>currentTarget</a></code> attribute value as <a>callback this value</a>. If this throws any exception, <a>report the exception</a>.
+   <li><p>Call <var>listener</var>'s <b>callback</b>'s <code>handleEvent</code>, with the event passed to this algorithm as the first argument and <var>event</var>'s <code>{{Event/currentTarget}}</code> attribute value as <a>callback this value</a>. If this throws any exception, <a>report the exception</a>.
     <ol>
      <li><p><a>Report the exception</a>.
 
@@ -617,7 +615,7 @@ for discussion).
    <li><p>Unset <var>event</var>'s <a>in passive listener flag</a>.
 
    <li><p>If <var>event</var>'s <a>stop immediate propagation flag</a> is set, then return
-   <var>found</var>.
+   <var ignore>found</var>.
 
   </ol>
  </li>

--- a/sections/historical.include
+++ b/sections/historical.include
@@ -62,7 +62,7 @@ and the <a href="http://www.w3.org/TR/2015/REC-dom-20151119/">DOM 4 Recommendati
  <dd>Queuing of mutation records looks inconsistent. To replace a child with node within a parent,
   the mutation record should be queued after the removal of <code>child</code> and insertion of <code>node</code></dd>
 <dt><a href="https://github.com/w3c/dom/commit/eb8190173bd1a174b651872708b708395fea5ef3">Remove the <code>unenumable</code> keyword</a></dt>
- <dd>For compatibility with <a>WebIDL</a></dd>
+ <dd>For compatibility with <cite>WEBIDL</cite></dd> [[!WEBIDL]]
 </dl>
 
 <h3 id="historical-DOM-spec-history">DOM Specification History</h3>
@@ -74,7 +74,7 @@ The Element Traversal Recommendation was published in 2008, and the Selectors AP
 
 Other DOM specifications have been in development during that time, and continue to be developed.
 
-Around 2009 some employees of Opera software began to write a new version of a DOM specification, which was then worked on by the "Web Hypertext Application Technology Working Group", and subsequently developed jointly with the W3C. The eventual goals of that works were described <a href="https://www.w3.org/TR/2015/REC-dom-20151119/#goals">in the DOM 4 Recommendation</a>. In November 2013 W3C produced a W3C First Public Working draft based on that work, and after subsequent development that became the W3C Recommendation <a>DOM 4</a>, in November 2015.
+Around 2009 some employees of Opera software began to write a new version of a DOM specification, which was then worked on by the "Web Hypertext Application Technology Working Group", and subsequently developed jointly with the W3C. The eventual goals of that works were described <a href="https://www.w3.org/TR/2015/REC-dom-20151119/#goals">in the DOM 4 Recommendation</a>. In November 2013 W3C produced a W3C First Public Working draft based on that work, and after subsequent development that became the W3C Recommendation <cite>DOM 4</cite>, in November 2015.
 
 The current DOM 4.1 revision is produced by W3C, with the primary aim of documenting what is interoperably implemented and is, or is likely to become, a core part of the Web Platform. An important secondary goal is to minimise incompatibility with the ongoing work at WHATWG.
 

--- a/sections/nodes.include
+++ b/sections/nodes.include
@@ -30,16 +30,16 @@
        <li class="t1">
         <a>Element</a>: <code>title</code>
         <ul>
-         <li class="t3"><code><a>Text</a></code>: <span>Aliens?</span></li>
+         <li class="t3"><code>{{Text}}</code>: <span>Aliens?</span></li>
         </ul>
        </li>
       </ul>
      </li>
-     <li class="t3"><code><a>Text</a></code>: <span>⏎␣</span></li>
+     <li class="t3"><code>{{Text}}</code>: <span>⏎␣</span></li>
      <li class="t1">
       <a>Element</a>: <code>body</code>
       <ul>
-       <li class="t3"><code><a>Text</a></code>: <span>Why yes.⏎</span></li>
+       <li class="t3"><code>{{Text}}</code>: <span>Why yes.⏎</span></li>
       </ul>
      </li>
     </ul>
@@ -48,88 +48,84 @@
  </li>
 </ul>
 
-<!--
-http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%0A%3Chtml%20class%3De%3E%0D%0A%20%3Chead%3E%3Ctitle%3EAliens%3F%3C%2Ftitle%3E%3C%2Fhead%3E%0D%0A%20%3Cbody%3EWhy%20yes.%3C%2Fbody%3E%0D%0A%3C%2Fhtml%3E
--->
+<p>Note that, due to the magic of <a>HTML parser</a>, not all <a>ASCII whitespace</a> were turned into <code>{{Text}}</code> <a>nodes</a>, but the general concept is clear. Markup goes in, a <a>tree</a> of <a>nodes</a> comes out.
 
-<p>Note that, due to the magic of <a>HTML parser</a>, not all <a>ASCII whitespace</a> were turned into <code><a>Text</a></code> <a>nodes</a>, but the general concept is clear. Markup goes in, a <a>tree</a> of <a>nodes</a> comes out.
-
-<p class="note">Note: The most excellent <a href="http://software.hixie.ch/utilities/js/live-dom-viewer/">Live DOM Viewer</a> can be used to explore this matter in more detail.
+<p class="note">Note: The most excellent <a>Live DOM Viewer</a> can be used to explore this matter in more detail.
 
 <h3 id="nodes-node-tree">Node tree</h3>
-<p>Objects implementing the <code><a>Document</a></code>, <code><a>DocumentFragment</a></code>, <code><a>DocumentType</a></code>, <code><a>Element</a></code>, <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> interface (simply called <dfn lt="node|nodes">nodes</dfn>) <a>participate</a> in a <a>tree</a>, simply named the <dfn>node tree</dfn>.
+<p>Objects implementing the <code>{{Document}}</code>, <code>{{DocumentFragment}}</code>, <code>{{DocumentType}}</code>, <code>{{Element}}</code>, <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> interface (simply called <dfn id="concept-node" lt="node|nodes">nodes</dfn>) <a>participate</a> in a <a>tree</a>, simply named the <dfn>node tree</dfn>.
 
-<p>A <a>node tree</a> is constrained as follows, expressed as a relationship between the type of <a>node</a> and its allowed <a>children</a>:
+<p>A <a>node tree</a> is constrained as follows, expressed as a relationship between the type of <a href="#concept-node">node</a> and its allowed <a>children</a>:
 <dl>
- <dt><code><a>Document</a></code>
+ <dt><code>{{Document}}</code>
  <dd>
   <p>In <a>tree order</a>:
   <ol>
-   <li><p>Zero or more nodes each of which is either <code><a>ProcessingInstruction</a></code> or <code><a href="#comment">Comment</a></code>.
-   <li><p>Optionally one <code><a>DocumentType</a></code> node.
-   <li><p>Zero or more nodes each of which is either <code><a>ProcessingInstruction</a></code> or <code><a>Comment</a></code>.
-   <li><p>Optionally one <code><a>Element</a></code> node.
-   <li><p>Zero or more nodes each of which is either <code><a>ProcessingInstruction</a></code> or <code><a>Comment</a></code>.
+   <li><p>Zero or more nodes each of which is either <code>{{ProcessingInstruction}}</code> or <code>{{Comment}}</code>.
+   <li><p>Optionally one <code>{{DocumentType}}</code> node.
+   <li><p>Zero or more nodes each of which is either <code>{{ProcessingInstruction}}</code> or <code>{{Comment}}</code>.
+   <li><p>Optionally one <code>{{Element}}</code> node.
+   <li><p>Zero or more nodes each of which is either <code>{{ProcessingInstruction}}</code> or <code>{{Comment}}</code>.
   </ol>
- <dt><code><a>DocumentFragment</a></code>
- <dt><code><a>Element</a></code>
- <dd><p>Zero or more nodes each of which is one of <code><a>Element</a></code>,
- <code><a>ProcessingInstruction</a></code>, <code><a>Comment</a></code>, or
- <code><a>Text</a></code>.
- <dt><code><a>DocumentType</a></code>
- <dt><code><a>Text</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
- <dt><code><a>Comment</a></code>
+ <dt><code>{{DocumentFragment}}</code>
+ <dt><code>{{Element}}</code>
+ <dd><p>Zero or more nodes each of which is one of <code><a href="#concept-element">Element</a></code>,
+ <code>{{ProcessingInstruction}}</code>, <code>{{Comment}}</code>, or
+ <code>{{Text}}</code>.
+ <dt><code>{{DocumentType}}</code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
+ <dt><code>{{Comment}}</code>
  <dd><p>None.
 </dl>
 <!--AttrExodus -->
 
-<p>To determine the <dfn id="node-length" for="node">length</dfn> of a <a>node</a> <var>node</var>,
+<p>To determine the <dfn id="node-length" for="node">length</dfn> of a <a href="#concept-node">node</a> <var>node</var>,
  switch on <var>node</var>:
 <dl class="switch">
- <dt><code><a>DocumentType</a></code>
+ <dt><code>{{DocumentType}}</code>
  <dd><p>Zero.
 
- <dt><code><a>Text</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
- <dt><code><a>Comment</a></code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
+ <dt><code>{{Comment}}</code>
  <dd><p>The number of <a>code units</a> in its <a>data</a>.
 
  <dt>Any other node
  <dd><p>Its number of <a>children</a>.
 </dl>
 
-<p>A <a>node</a> is considered <dfn>empty</dfn> if its <a href="#node-length">length</a> is zero.
+<p>A <a href="#concept-node">node</a> is considered <dfn>empty</dfn> if its <a href="#node-length">length</a> is zero.
 
 <h4 id="mutation-algorithms">Mutation algorithms</h4>
 
 <p>To <dfn>ensure pre-insertion validity</dfn> of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
 
 <ol>
- <li><p>If <var>parent</var> is not a <code><a>Document</a></code>, <code><a>DocumentFragment</a></code>, or <code><a>Element</a></code> <a>node</a>,
+ <li><p>If <var>parent</var> is not a <code>{{Document}}</code>, <code>{{DocumentFragment}}</code>, or <code>{{Element}}</code> <a href="#concept-node">node</a>,
  <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li><p>If <var>node</var> is a <a>host-including inclusive ancestor</a> of <var>parent</var>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li><p>If <var>child</var> is not null and its <a>parent</a> is not <var>parent</var>, <a>throw</a> a "<code><a>NotFoundError</a></code>".
 
- <li><p>If <var>node</var> is not a <code><a>DocumentFragment</a></code>, <code><a>DocumentType</a></code>, <code><a>Element</a></code>, <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+ <li><p>If <var>node</var> is not a <code>{{DocumentFragment}}</code>, <code>{{DocumentType}}</code>, <code>{{Element}}</code>, <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
- <li><p>If either <var>node</var> is a <code><a>Text</a></code> <a>node</a> and <var>parent</var> is a <a>document</a>, or <var>node</var> is a <a>doctype</a> and <var>parent</var> is not a <a>document</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+ <li><p>If either <var>node</var> is a <code>{{Text}}</code> <a href="#concept-node">node</a> and <var>parent</var> is a <a href="#concept-document">document</a>, or <var>node</var> is a <a href="#concept-doctype">doctype</a> and <var>parent</var> is not a <a href="#concept-document">document</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
  <li>
-  <p>If <var>parent</var> is a <a>document</a>, and any of the statements below, switched on <var>node</var>, are true, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+  <p>If <var>parent</var> is a <a href="#concept-document">document</a>, and any of the statements below, switched on <var>node</var>, are true, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
   <dl class="switch">
-   <dt><code><a>DocumentFragment</a></code> <a>node</a>
+   <dt><code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>
    <dd>
-    <p>If <var>node</var> has more than one <a>element</a> <a>child</a> or has a <code><a>Text</a></code> <a>node</a> <a>child</a>.
+    <p>If <var>node</var> has more than one {{element}} <a>child</a> or has a <code>{{Text}}</code> <a href="#concept-node">node</a> <a>child</a>.
 
-    <p>Otherwise, if <var>node</var> has one <a>element</a> <a>child</a> and either <var>parent</var> has an <a>element</a> <a>child</a>, <var>child</var> is a <a>doctype</a>, or <var>child</var> is not null and a <a>doctype</a> is <a>following</a> <var>child</var>.
+    <p>Otherwise, if <var>node</var> has one {{element}} <a>child</a> and either <var>parent</var> has an {{element}} <a>child</a>, <var>child</var> is a <a href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a href="#concept-doctype">doctype</a> is <a>following</a> <var>child</var>.
 
-   <dt><a>element</a> <dd><p><var>parent</var> has an <a>element</a> <a>child</a>, <var>child</var> is a <a>doctype</a>, or <var>child</var> is not null and a <a>doctype</a> is <a>following</a> <var>child</var>.
+   <dt>{{element}} <dd><p><var>parent</var> has an {{element}} <a>child</a>, <var>child</var> is a <a href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a href="#concept-doctype">doctype</a> is <a>following</a> <var>child</var>.
 
-   <dt><a>doctype</a> <dd><p><var>parent</var> has a <a>doctype</a> <a>child</a>, <var>child</var> is non-null and an <a>element</a> is <a>preceding</a> <var>child</var>, or <var>child</var> is null and <var>parent</var> has an <a>element</a> <a>child</a>.
+   <dt><a href="#concept-doctype">doctype</a> <dd><p><var>parent</var> has a <a href="#concept-doctype">doctype</a> <a>child</a>, <var>child</var> is non-null and an <a href="#concept-element">element</a> is <a>preceding</a> <var>child</var>, or <var>child</var> is null and <var>parent</var> has an {{element}} <a>child</a>.
   </dl>
 </ol>
 
@@ -144,7 +140,7 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 
  <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a>node document</a>.
 
- <li><p><a>Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>.
+ <li><p><a href="#node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>.
 
  <li><p>Return <var>node</var>.
 </ol>
@@ -154,21 +150,21 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 <p>To <dfn id="node-insert" for="node">insert</dfn> a <var>node</var> into a <var>parent</var> before a <var>child</var> with an optional <i>suppress observers flag</i>, run these steps:
 
 <ol>
- <li><p>Let <var>count</var> be the number of <a>children</a> of <var>node</var> if it is a <code><a>DocumentFragment</a></code> <a>node</a>, and one otherwise.
+ <li><p>Let <var>count</var> be the number of <a>children</a> of <var>node</var> if it is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, and one otherwise.
 
  <li>
   <p>If <var>child</var> is non-null, run these substeps:
 
   <ol>
-   <li><p>For each <a>range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is greater than <var>child</var>'s <a>index</a>, increase its <a>start offset</a> by <var>count</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is greater than <var>child</var>'s <a>index</a>, increase its <a>start offset</a> by <var>count</var>.
 
-   <li><p>For each <a>range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is greater than <var>child</var>'s <a>index</a>, increase its <a>end offset</a> by <var>count</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is greater than <var>child</var>'s <a>index</a>, increase its <a>end offset</a> by <var>count</var>.
   </ol>
 
- <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, and a list containing solely <var>node</var> otherwise.
+ <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise.
 
- <li><p>If <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, <a href="#node-remove">remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
-  <p>If <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, <a>queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>.
+ <li><p>If <var>node</var> is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, <a href="#node-remove">remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
+  <p>If <var>node</var> is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, <a>queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>.
 
   <p class="note">Note: This step intentionally does not pay attention to the <i>suppress observers flag</i>.
  <li>
@@ -204,7 +200,7 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
   <p>If <var>parent</var> is a <a href="#concept-document">document</a>, and any of the statements below, switched on <var>node</var>, are true, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
   <dl class="switch">
-   <dt>{{{DocumentFragment}}} <a href="#concept-node">node</a>
+   <dt>{{DocumentFragment}} <a href="#concept-node">node</a>
    <dd>
     <p>If <var>node</var> has more than one <a href="#concept-element">element</a> <a>child</a> or has a {{Text}} <a href="#concept-node">node</a> <a>child</a>.
 
@@ -257,7 +253,7 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 
  <li><p>Let <var>removedNodes</var> be <var>parent</var>'s <a>children</a>.
 
- <li><p>Let <var>addedNodes</var> be the empty list if <var>node</var> is null, <var>node</var>'s <a>children</a> if <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, and a list containing <var>node</var> otherwise.
+ <li><p>Let <var>addedNodes</var> be the empty list if <var>node</var> is null, <var>node</var>'s <a>children</a> if <var>node</var> is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, and a list containing <var>node</var> otherwise.
 
  <li><p><a href="#node-remove">Remove</a> all <var>parent</var>'s <a>children</a>, in <a>tree order</a>, with the <i>suppress observers flag</i> set.
 
@@ -283,20 +279,20 @@ http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%
 <p><a lt="Other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-remove-ext>removing steps</dfn> for all or some <a>nodes</a>. The
 algorithm is passed <var ignore>removedNode</var>, and optionally <var ignore>oldParent</var>, as
-indicated in the <a>remove</a> algorithm below.
+indicated in the <a href="#node-remove">remove</a> algorithm below.
 
 <p>To <dfn id="node-remove" for="node">remove</dfn> a <var>node</var> from a <var>parent</var> with an optional <i>suppress observers flag</i> set, run these steps:
 
 <ol>
  <li><p>Let <var>index</var> be <var>node</var>'s <a>index</a>.
 
- <li><p>For each <a>range</a> whose <a>start node</a> is an <a>inclusive descendant</a> of <var>node</var>, set its <a>start</a> to (<var>parent</var>, <var>index</var>).
+ <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is an <a>inclusive descendant</a> of <var>node</var>, set its <a>start</a> to (<var>parent</var>, <var>index</var>).
 
- <li><p>For each <a>range</a> whose <a>end node</a> is an <a>inclusive descendant</a> of <var>node</var>, set its <a>end</a> to (<var>parent</var>, <var>index</var>).
+ <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is an <a>inclusive descendant</a> of <var>node</var>, set its <a>end</a> to (<var>parent</var>, <var>index</var>).
 
- <li><p>For each <a>range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is greater than <var>index</var>, decrease its <a>start offset</a> by one.
+ <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is greater than <var>index</var>, decrease its <a>start offset</a> by one.
 
- <li><p>For each <a>range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is greater than <var>index</var>, decrease its <a>end offset</a> by one.
+ <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is greater than <var>index</var>, decrease its <a>end offset</a> by one.
 
  <li><p>For each {{NodeIterator}} object <var>iterator</var> whose <a for=traversal>root</a>'s <a>node document</a> is <var>node</var>'s
  <a>node document</a>, run the <a><code>NodeIterator</code> pre-removing steps</a> given <var>node</var> and <var>iterator</var>.
@@ -314,7 +310,7 @@ indicated in the <a>remove</a> algorithm below.
 
 </ol>
 
-<h4 id="interface-nonelementparentnode">Interface <code><a>NonElementParentNode</a></code></h4>
+<h4 id="interface-nonelementparentnode">Interface <code>{{NonElementParentNode}}</code></h4>
 
 <p class="note no-backref">Web compatibility prevents the {{NonElementParentNode/getElementById()}}
 method from being exposed on <a href="#concept-element">elements</a> (and therefore on {{ParentNode}}).
@@ -330,13 +326,13 @@ DocumentFragment implements NonElementParentNode;
 </pre>
 
 <dl>
- <dt><code><var>node</var> . <a>getElementById</a>(<var>elementId</var>)</code>
- <dd><p>Returns the first <a>element</a> within <var>node</var>'s <a>descendants</a> whose <a>ID</a> is <var>elementId</var>.
+ <dt><code><var>node</var> . {{NonElementParentNode/getElementById(elementId)}}</code>
+ <dd><p>Returns the first <a href="#concept-element">element</a> within <var>node</var>'s <a>descendants</a> whose <a>ID</a> is <var>elementId</var>.
 </dl>
 
-<p>The <dfn><code>getElementById(<var>elementId</var>)</code></dfn> method must return the first <a>element</a>, in <a>tree order</a>, within <a>context object</a>'s <a>descendants</a>, whose <a>ID</a> is <var>elementId</var>, and null if there is no such <a>element</a> otherwise.
+<p>The <dfn method for=NonElementParentNode><code>getElementById(<var>elementId</var>)</code></dfn> method, when invoked, must return the first <a href="#concept-element">element</a>, in <a>tree order</a>, within <a>context object</a>'s <a>descendants</a>, whose <a>ID</a> is <var>elementId</var>, and null if there is no such <a href="#concept-element">element</a> otherwise.
 
-<h4 id="interface-parentnode">Interface <code><a>ParentNode</a></code></h4>
+<h4 id="interface-parentnode">Interface <code>{{ParentNode}}</code></h4>
 
 To <dfn export lt="converting nodes into a node">convert nodes into a node</dfn>, given
 <var>nodes</var> and <var>document</var>, run these steps:
@@ -352,7 +348,7 @@ To <dfn export lt="converting nodes into a node">convert nodes into a node</dfn>
  <a href="#concept-node">node</a>.
 
  <li><p>Otherwise, set <var>node</var> to a new {{DocumentFragment}} whose
- <a>node document</a> is <var>document</var>, and then <a>append</a> each <a href="#concept-node">node</a> in
+ <a>node document</a> is <var>document</var>, and then <a href="#node-append">append</a> each <a href="#concept-node">node</a> in
  <var>nodes</var>, if any, to it.
 
  <li><p>Return <var>node</var>.
@@ -379,13 +375,13 @@ Element implements ParentNode;
 </pre>
 
 <dl>
- <dt><code><var>collection</var> = <var>node</var> . {{ParentNode/children}}
+ <dt><code><var ignore>collection</var> = <var>node</var> . {{ParentNode/children}}
  <dd><p>Returns the <a>child</a> <a href="#concept-element">elements</a>.
 
- <dt><code><var>element</var> = <var>node</var> . {{ParentNode/firstElementChild}}
+ <dt><code><var ignore>element</var> = <var>node</var> . {{ParentNode/firstElementChild}}
  <dd><p>Returns the first <a>child</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
- <dt><code><var>element</var> = <var>node</var> . {{ParentNode/lastElementChild}}
+ <dt><code><var ignore>element</var> = <var>node</var> . {{ParentNode/lastElementChild}}
  <dd><p>Returns the last <a>child</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
  <!-- childElementCount is redundant -->
@@ -414,11 +410,11 @@ Element implements ParentNode;
 </dl>
 
 <p>The <dfn attribute id="parentnode-children" for=ParentNode><code>children</code></dfn> attribute's getter must return an
-<code>{{HTMLCollection}}</code> <a>collection</a> rooted at the <a>context object</a> matching only <a>element</a> <a>children</a>.
+<code>{{HTMLCollection}}</code> <a>collection</a> rooted at the <a>context object</a> matching only <a href="#concept-element">element</a> <a>children</a>.
 
-<p>The <dfn attribute for=ParentNode><code>firstElementChild</code></dfn> attribute's getter must return the first <a>child</a> that is an <a>element</a>, and null otherwise.
+<p>The <dfn attribute for=ParentNode><code>firstElementChild</code></dfn> attribute's getter must return the first <a>child</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
-<p>The <dfn attribute for=ParentNode><code>lastElementChild</code></dfn> attribute's getter must return the last <a>child</a> that is an <a>element</a>, and null otherwise.
+<p>The <dfn attribute for=ParentNode><code>lastElementChild</code></dfn> attribute's getter must return the last <a>child</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
 <p>The <dfn attribute for=ParentNode><code>childElementCount</code></dfn> attribute's getter must return the number of <a>children</a> of the <a>context object</a> that are <a>elements</a>.
 
@@ -440,14 +436,14 @@ must run these steps:
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
  <var>nodes</var> and <a>context object</a>'s <a>node document</a>.
 
- <li><p><a>Append</a> <var>node</var> to <a>context object</a>.
+ <li><p><a href="#node-append">append</a> <var>node</var> to <a>context object</a>.
 </ol>
 
 <p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method, when invoked, must return the first result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>, and null if the result is an empty list otherwise.
 
 <p>The <dfn method for=ParentNode><code>querySelectorAll(<var>selectors</var>)</code></dfn> method, when invoked, must return the <a>static</a> result of running <a>scope-match a selectors string</a> <var>selectors</var> against the <a>context object</a>.
 
-<h4 id="interface-nondocumenttypechildnode">Interface <code><a >NonDocumentTypeChildNode</a></code></h4>
+<h4 id="interface-nondocumenttypechildnode">Interface <code>{{NonDocumentTypeChildNode}}</code></h4>
 
 <p class="note no-backref">Web compatibility prevents the {{previousElementSibling}} and
 {{nextElementSibling}} attributes from being exposed on <a href="#concept-doctype">doctypes</a> (and therefore on
@@ -465,18 +461,18 @@ CharacterData implements NonDocumentTypeChildNode;
 </pre>
 
 <dl>
-<dt><code><var>element</var> = <var>node</var> . <a>previousElementSibling</a></code>
- <dd><p>Returns the first <a>preceding</a> <a>sibling</a> that is an <a>element</a>, and null otherwise.
+<dt><code><var ignore>element</var> = <var>node</var> . {{NonDocumentTypeChildNode/previousElementSibling}}</code>
+ <dd><p>Returns the first <a>preceding</a> <a>sibling</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
- <dt><code><var>element</var> = <var>node</var> . <a>nextElementSibling</a></code>
- <dd><p>Returns the first <a>following</a> <a>sibling</a> that is an <a>element</a>, and null otherwise.
+ <dt><code><var ignore>element</var> = <var>node</var> . {{NonDocumentTypeChildNode/nextElementSibling}}</code>
+ <dd><p>Returns the first <a>following</a> <a>sibling</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 </dl>
 
-<p>The <dfn><code>previousElementSibling</code></dfn> attribute must return the first <a>preceding</a> <a>sibling</a> that is an <a>element</a>, and null otherwise.
+<p>The <dfn><code>previousElementSibling</code></dfn> attribute's getter must return the first <a>preceding</a> <a>sibling</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
-<p>The <dfn><code>nextElementSibling</code></dfn> attribute must return the first <a>following</a> <a>sibling</a> that is an <a>element</a>, and null otherwise.
+<p>The <dfn><code>nextElementSibling</code></dfn> attribute's getter must return the first <a>following</a> <a>sibling</a> that is an <a href="#concept-element">element</a>, and null otherwise.
 
-<h4 id="interface-childnode">Interface <code><a>ChildNode</a></code></h4>
+<h4 id="interface-childnode">Interface <code>{{ChildNode}}</code></h4>
 <pre class='idl'>
 [NoInterfaceObject,
  Exposed=Window]
@@ -531,8 +527,7 @@ must run these steps:
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before <var>viablePreviousSibling</var>.
 </ol>
 
-<p>The <dfn method for=ChildNode><code>after(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ChildNode><code>after(<var>nodes</var>)</code></dfn> method, when invoked,  must run these steps:
 
 <ol>
  <li><p>Let <var>parent</var> be <a>context object</a>'s <a href="#tree-parent">parent</a>.
@@ -564,7 +559,7 @@ invoked, must run these steps:
  <var>nodes</var> and <a>context object</a>'s <a>node document</a>.
 
  <li>
-  <p>If <a>context object</a>'s <a href="#tree-parent">parent</a> is <var>parent</var>, <a>replace</a> the
+  <p>If <a>context object</a>'s <a href="#tree-parent">parent</a> is <var>parent</var>, <a href="#node-replace">replace</a> the
   <a>context object</a> with <var>node</var> within <var>parent</var>.
 
   <p class=note><a>Context object</a> could have been inserted into <var>node</var>.
@@ -573,7 +568,7 @@ invoked, must run these steps:
  <var>viableNextSibling</var>.
 </ol>
 
-<p>The <dfn method id="node-remove-func" for="ChildNode"><code>remove()</code></dfn> method must run these steps:
+<p>The <dfn method id="node-remove-func" for=ChildNode><code>remove()</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If the <a>context object</a> does not have a <a href="#tree-parent">parent</a>, terminate these steps.
@@ -581,7 +576,7 @@ invoked, must run these steps:
  <li><p><a href="#node-remove">Remove</a> the <a>context object</a> from the <a>context object</a>'s <a>parent</a>.
 </ol>
 
-<h4 id="old-style-collections:-nodelist-and-htmlcollection">Old-style collections: <code><a>NodeList</a></code> and <code><a>HTMLCollection</a></code></h4>
+<h4 id="old-style-collections:-nodelist-and-htmlcollection">Old-style collections: <code>{{NodeList}}</code> and <code>{{HTMLCollection}}</code></h4>
 
 <p>A <dfn>collection</dfn> is an object that represents a lists of DOM nodes. A <a>collection</a> can be either <dfn>live</dfn> or <dfn>static</dfn>. Unless otherwise stated, a <a>collection</a> must be <a>live</a>.
 
@@ -591,39 +586,39 @@ invoked, must run these steps:
 
 <p>The <a>collection</a> then <dfn>represents</dfn> a view of the subtree rooted at the <a>collection's</a> root, containing only nodes that match the given filter. The view is linear. In the absence of specific requirements to the contrary, the nodes within the <a>collection</a> must be sorted in <a>tree order</a>.
 
-<h5 id="interface-nodelist">Interface <code><a>NodeList</a></code></h5>
+<h5 id="interface-nodelist">Interface <code>{{NodeList}}</code></h5>
 
-<p>A <code><a>NodeList</a></code> object is a <a>collection</a> of <a>nodes</a>.
+<p>A <code>{{NodeList}}</code> object is a <a>collection</a> of <a>nodes</a>.
 
 <pre class='idl'>
 [Exposed=Window]
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-  iterable<Node>;
+  iterable&lt;Node>;
 };
 </pre>
 
 <dl>
- <dt><var>collection</var> . <code><a href="#nodelist-length">length</a></code>
+ <dt><var>collection</var> . {{NodeList/length}}
  <dd><p>Returns the number of <a>nodes</a> in the <a>collection</a>.
 
- <dt><var>element</var> = <var>collection</var> . <code><a>item</a></code>(<var>index</var>)
- <dt><var>element</var> = <var>collection</var>[<var>index</var>]
- <dd><p>Returns the <a>node</a> with index <var>index</var> from the <a>collection</a>. The <a>nodes</a> are sorted in <a>tree order</a>.
+ <dt><var ignore>element</var> = <var>collection</var> . {{NodeList/item(index)}}
+ <dt><var ignore>element</var> = <var>collection</var>[<var>index</var>]
+ <dd><p>Returns the <a href="#concept-node">node</a> with index <var>index</var> from the <a>collection</a>. The <a>nodes</a> are sorted in <a>tree order</a>.
 </dl>
 
 <div>
 
-<p>The object's <a class="external" data-anolis-spec="webidl" href="http://www.w3.org/TR/WebIDL-1/#dfn-supported-property-indices">supported property indices</a> are the numbers in the range zero to one less than the number of nodes <a>represented by the collection</a>. If there are no such elements, then there are no <a>supported property indices</a>.
+<p>The object's <a class="external" data-anolis-spec="webidl">supported property indices</a> are the numbers in the range zero to one less than the number of nodes <a>represented by the collection</a>. If there are no such elements, then there are no <a>supported property indices</a>.
 
-<p>The <dfn id="nodelist-length" for="nodeList"><code>length</code></dfn> attribute must return the number of nodes <a>represented by the collection</a>.
+<p>The <dfn attribute id="nodelist-length" for=NodeList><code>length</code></dfn> attribute's getter must return the number of nodes <a>represented by the collection</a>.
 
-<p>The <dfn id="nodelist-item-func" for="nodelist"><code>item(<var>index</var>)</code></dfn> method must return the <var>index</var>th node in the <a>collection</a>. If there is no <var>index</var>th node in the <a>collection</a>, then the method must return null.
+<p>The <dfn method id="nodelist-item-func" for=NodeList><code>item(<var>index</var>)</code></dfn> method, when invoked, must return the <var>index</var>th node in the <a>collection</a>. If there is no <var>index</var>th node in the <a>collection</a>, then the method, when invoked, must return null.
 
 </div>
 
-<h5 id="interface-htmlcollection">Interface <code><a>HTMLCollection</a></code></h5>
+<h5 id="interface-htmlcollection">Interface <code>{{HTMLCollection}}</code></h5>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -641,25 +636,25 @@ interface HTMLCollection {
  it (use <code>sequence&lt;T></code> in IDL instead).
 
 <dl>
- <dt><var>collection</var> . <code><a href="#htmlcollection-length">length</a></code>
+ <dt><var>collection</var> . {{HTMLCollection/length}}
  <dd><p>Returns the number of <a href="#concept-element">elements</a> in the <a>collection</a>.
 
- <dt><var>element</var> = <var>collection</var> . <code><a>item</a></code>(<var>index</var>)
- <dt><var>element</var> = <var>collection</var>[<var>index</var>]
- <dd><p>Returns the <a>element</a> with index <var>index</var> from the <a>collection</a>. The <a>elements</a> are sorted in <a>tree order</a>.
+ <dt><var ignore>element</var> = <var>collection</var> . {{HTMLCollection/item(index)}}
+ <dt><var ignore>element</var> = <var>collection</var>[<var>index</var>]
+ <dd><p>Returns the <a href="#concept-element">element</a> with index <var>index</var> from the <a>collection</a>. The <a>elements</a> are sorted in <a>tree order</a>.
 
- <dt><var>element</var> = <var>collection</var> . <code><a>namedItem</a></code>(<var>name</var>)
- <dt><var>element</var> = <var>collection</var>[<var>name</var>]
- <dd><p>Returns the first <a>element</a> with <a>ID</a> or name <var>name</var>from the collection.
+ <dt><var ignore>element</var> = <var>collection</var> . {{HTMLCollection/namedItem(name)}}
+ <dt><var ignore>element</var> = <var>collection</var>[<var>name</var>]
+ <dd><p>Returns the first <a href="#concept-element">element</a> with <a>ID</a> or name <var>name</var>from the collection.
 </dl>
 
 <div>
 
 <p>The object's <a>supported property indices</a> are the numbers in the range zero to one less than the number of elements <a>represented by the collection</a>. If there are no such elements, then there are no <a>supported property indices</a>.
 
-<p>The <dfn id="htmlcollection-length" for="HTMLCollection"><code>length</code></dfn> attribute's getter must return the number of nodes <a>represented by the collection</a>.
+<p>The <dfn attribute id="htmlcollection-length" for=HTMLCollection><code>length</code></dfn> attribute's getter must return the number of nodes <a>represented by the collection</a>.
 
-<p>The <dfn id="htmlcollection-item-func" for="HTMLCollection"><code>item(<var>index</var>)</code></dfn> method must return the <var>index</var>th <a>element</a> in the <a>collection</a>. If there is no <var>index</var>th <a>element</a> in the <a>collection</a>, then the method must return null.
+<p>The <dfn method id="htmlcollection-item-func" for=HTMLCollection><code>item(<var>index</var>)</code></dfn> method, when invoked, must return the <var>index</var>th <a href="#concept-element">element</a> in the <a>collection</a>. If there is no <var>index</var>th <a href="#concept-element">element</a> in the <a>collection</a>, then the method, when invoked, must return null.
 
 <p>The <a>supported property names</a> are the values from the list returned by these steps:
 
@@ -676,24 +671,24 @@ interface HTMLCollection {
  <li><p>Return <var>result</var>.
 </ol>
 
-<p>The <dfn><code>namedItem(<var>key</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=HTMLCollection><code>namedItem(<var>key</var>)</code></dfn> method, when invoked, must run these steps:
 <ol>
  <li>If <var>key</var> is the empty string, return null.</li>
  <li>
-  <p>Return the first <a>element</a> in the <a>collection</a> for which at least one of the following is true:
+  <p>Return the first <a href="#concept-element">element</a> in the <a>collection</a> for which at least one of the following is true:
   <ul>
    <li>it has an <a>ID</a> which is <var>key</var>;
-   <li>it is in the <a>HTML namespace</a> and <a href="#concept-element-attribute-has" title="concept-element-attribute-has">has</a> a
+   <li>it is in the <a>HTML namespace</a> and <a>has</a> a
    <a href="#named-attribute"><code>name</code> attribute</a> whose <a href="#attribute-value">value</a> is <var>key</var>;
   </ul>
-  <p>or null if there is no such <a>element</a>.
+  <p>or null if there is no such <a href="#concept-element">element</a>.
 </ol>
 
 </div>
 
 <h3 id="nodes-mutation-observers">Mutation observers</h3>
 <p>Each <a>unit of related similar-origin browsing contexts</a> has a <dfn>mutation observer compound microtask queued flag</dfn>, which is initially unset,
-and an associated list of <code><a>MutationObserver</a></code> objects, which is initially empty.
+and an associated list of <code>{{MutationObserver}}</code> objects, which is initially empty.
 
 <p>To <dfn>queue a mutation observer compound microtask</dfn>, run these steps:
 
@@ -702,7 +697,7 @@ and an associated list of <code><a>MutationObserver</a></code> objects, which is
 
  <li><p>Set <a>mutation observer compound microtask queued flag</a>.
 
- <li><p><a href="http://www.w3.org/TR/html51/webappapis.html#queue-a-microtask">Queue</a> a <a>compound microtask</a> to <a>notify mutation observers</a>.
+ <li><p><a>Queue</a> a <a>compound microtask</a> to <a>notify mutation observers</a>.
 </ol>
 
 <p>To <dfn>notify mutation observers</dfn>, run these steps:
@@ -710,10 +705,10 @@ and an associated list of <code><a>MutationObserver</a></code> objects, which is
 <ol>
  <li><p>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li><p>Let <var>notify list</var> be a copy of <a>unit of related similar-origin browsing contexts</a>' list of <code><a>MutationObserver</a></code> objects.
+ <li><p>Let <var>notify list</var> be a copy of <a>unit of related similar-origin browsing contexts</a>' list of <code>{{MutationObserver}}</code> objects.
 
  <li>
-  <p>For each <code><a>MutationObserver</a></code> object <var>mo</var> in <var>notify list</var>, <a>execute a compound microtask subtask</a> to run these steps:
+  <p>For each <code>{{MutationObserver}}</code> object <var>mo</var> in <var>notify list</var>, <a>execute a compound microtask subtask</a> to run these steps:
 
   <ol>
    <li><p>Let <var>queue</var> be a copy of <var>mo</var>'s <a>record queue</a>.
@@ -722,33 +717,33 @@ and an associated list of <code><a>MutationObserver</a></code> objects, which is
 
    <li><p>Remove all <a>transient registered observers</a> whose <b>observer</b> is <var>mo</var>.
 
-   <li><p>If <var>queue</var> is non-empty, call <var>mo</var>'s <a>callback</a> with <var>queue</var> as first argument, and <var>mo</var> (itself) as second argument and <a>callback this value</a>. If this throws an exception, <a>report the exception</a>.
+   <li><p>If <var>queue</var> is non-empty, call <var>mo</var>'s <a href="#concept-mo-callback">callback</a> with <var>queue</var> as first argument, and <var>mo</var> (itself) as second argument and <a>callback this value</a>. If this throws an exception, <a>report the exception</a>.
   </ol>
 </ol>
 
 <hr>
 
-<p>Each <a>node</a> has an associated list of <a>registered observers</a>.
+<p>Each <a href="#concept-node">node</a> has an associated list of <a>registered observers</a>.
 
-<p>A <dfn>registered observer</dfn> consists of an <b>observer</b> (a <code><a>MutationObserver</a></code> object) and <b>options</b> (a <code><a>MutationObserverInit</a></code> dictionary).
+<p>A <dfn>registered observer</dfn> consists of an <b>observer</b> (a <code>{{MutationObserver}}</code> object) and <b>options</b> (a <code>{{MutationObserverInit}}</code> dictionary).
  A <dfn>transient registered observer</dfn> is a specific type of <a>registered observer</a> that has a <b>source</b> which is a <a>registered observer</a>.
 
 <p class="note no-backref"><a>Transient registered observers</a> are used to track
-mutations within a given <a>node</a>'s <a>descendants</a> after <a>node</a> has been
-removed so they do not get lost when <code>subtree</code> is set to true on <a>node</a>'s
+mutations within a given <a href="#concept-node">node</a>'s <a>descendants</a> after <a href="#concept-node">node</a> has been
+removed so they do not get lost when <code>subtree</code> is set to true on <a href="#concept-node">node</a>'s
 <a>parent</a>.
 
-<h4 id="interface-mutationobserver">Interface <code><a>MutationObserver</a></code></h4>
+<h4 id="interface-mutationobserver">Interface <code>{{MutationObserver}}</code></h4>
 
 <pre class='idl'>
 [Constructor(MutationCallback callback)]
 interface MutationObserver {
-  void observe(Node target, MutationObserverInit options);
+  void observe(Node target, optional MutationObserverInit options);
   void disconnect();
-  sequence<MutationRecord> takeRecords();
+  sequence&lt;MutationRecord> takeRecords();
 };
 
-callback MutationCallback = void (sequence<MutationRecord> mutations, MutationObserver observer);
+callback MutationCallback = void (sequence&lt;MutationRecord> mutations, MutationObserver observer);
 
 dictionary MutationObserverInit {
   boolean childList = false;
@@ -761,21 +756,21 @@ dictionary MutationObserverInit {
 };
 </pre>
 
-<p>A <code><a>MutationObserver</a></code> object can be used to observe mutations to the <a>tree</a> of <a>nodes</a>.
+<p>A <code>{{MutationObserver}}</code> object can be used to observe mutations to the <a>tree</a> of <a>nodes</a>.
 
-<p>Each <code><a>MutationObserver</a></code> object has these associated concepts:
+<p>Each <code>{{MutationObserver}}</code> object has these associated concepts:
 <ul>
- <li><p>A <dfn>callback</dfn> set on creation.
+ <li><p>A <dfn id="concept-mo-callback">callback</dfn> set on creation.
  <li><p>A list of <a>nodes</a> on which it is a <a>registered observer</a>'s <b>observer</b> that is initially empty.
- <li><p>A list of <code><a>MutationRecord</a></code> objects called the <dfn>record queue</dfn> that is initially empty.
+ <li><p>A list of <code>{{MutationRecord}}</code> objects called the <dfn>record queue</dfn> that is initially empty.
 </ul>
 
 <dl>
- <dt><code><var>observer</var> = new <a>MutationObserver</a>(<var>callback</var>)</code>
- <dd><p>Constructs a <code><a>MutationObserver</a></code> object and sets its <a>callback</a> to <var>callback</var>. The <var>callback</var> is invoked with a list of <code><a>MutationRecord</a></code> objects as first argument and the constructed <code><a>MutationObserver</a></code> object as second argument. It is invoked after <a>nodes</a> registered with the <code><a>observe()</a></code> method, are mutated.
+ <dt><code><var ignore>observer</var> = new {{MutationObserver(callback)}}</code>
+ <dd><p>Constructs a <code>{{MutationObserver}}</code> object and sets its <a href="#concept-mo-callback">callback</a> to <var>callback</var>. The <var>callback</var> is invoked with a list of <code>{{MutationRecord}}</code> objects as first argument and the constructed <code>{{MutationObserver}}</code> object as second argument. It is invoked after <a>nodes</a> registered with the <code><a>observe()</a></code> method, are mutated.
 
- <dt><code><var>observer</var> . <a>observe</a>(<var>target</var>, <var>options</var>)</code>
- <dd><p>Instructs the user agent to observe a given <var>target</var> (a <a>node</a>) and report any mutations based on the criteria given by <var>options</var> (an object).
+ <dt><code><var>observer</var> . {{MutationObserver/observe(target, options)}}
+ <dd><p>Instructs the user agent to observe a given <var>target</var> (a <a href="#concept-node">node</a>) and report any mutations based on the criteria given by <var>options</var> (an object).
 
   <p>The <var>options</var> argument allows for setting mutation observation options via object members. These are the object members that can be used:
 
@@ -798,32 +793,32 @@ dictionary MutationObserverInit {
    <dd><p>Set to true if <code>characterData</code> is set to true or omitted and <var>target</var>'s <a href="#cd-data">data</a> before the mutation needs to be recorded.
 
    <dt><code>attributeFilter</code>
-   <dd><p>Set to a list of <a href="#concept-attribute">attribute</a> <a>local names</a> (without <a href="#attribute-namespace">namespace</a>) if not all <a href="#concept-attribute">attribute</a> mutations need to be observed and <code>attributes</code> is true or omitted.
+   <dd><p>Set to a list of <a href="#concept-attribute">attribute</a> <a href="#attribute-local-name">local names</a> (without <a href="#attribute-namespace">namespace</a>) if not all <a href="#concept-attribute">attribute</a> mutations need to be observed and <code>attributes</code> is true or omitted.
   </dl>
 
- <dt><code><var>observer</var> . <a>disconnect</a>()</code>
- <dd><p>Stops <var>observer</var> from observing any mutations. Until the <code><a>observe()</a></code> method is used again, <var>observer</var>'s <a>callback</a> will not be invoked.
+ <dt><code><var>observer</var> . {{MutationObserver/disconnect()}}</code>
+ <dd><p>Stops <var>observer</var> from observing any mutations. Until the <code><a>observe()</a></code> method is used again, <var>observer</var>'s <a href="#concept-mo-callback">callback</a> will not be invoked.
 
- <dt><code><var>observer</var> . <a>takeRecords</a>()</code>
+ <dt><code><var>observer</var> . {{MutationObserver/takeRecords()}}</code>
  <dd><p>Empties the <a>record queue</a> and returns what was in there.
 </dl>
 
-<p>The <dfn><code>MutationObserver(<var>callback</var>)</code></dfn> constructor must create a new <code><a>MutationObserver</a></code> object with <a>callback</a> set to <var>callback</var>, append it to the <a>unit of related similar-origin browsing contexts</a>' list of <code><a>MutationObserver</a></code> objects, and then return it.
+<p>The <dfn constructor for=MutationObserver><code>MutationObserver(<var>callback</var>)</code></dfn> constructor must create a new <code>{{MutationObserver}}</code> object with <a href="#concept-mo-callback">callback</a> set to <var>callback</var>, append it to the <a>unit of related similar-origin browsing contexts</a>' list of <code>{{MutationObserver}}</code> objects, and then return it.
 
-<p>The <dfn><code>observe(<var>target</var>, <var>options</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=MutationObserver><code>observe(<var>target</var>, <var>options</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If either <var>options</var>' <code>attributeOldValue</code> or <code>attributeFilter</code> is present and <var>options</var>' <code>attributes</code> is omitted, set <var>options</var>' <code>attributes</code> to true.
 
  <li><p>If <var>options</var>' <code>characterDataOldValue</code> is present and <var>options</var>' <code>characterData</code> is omitted, set <var>options</var>' <code>characterData</code> to true.
 
- <li><p>If none of <var>options</var>' <code>childList</code>, <code>attributes</code>, and <code>characterData</code> is true, <a href="http://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a> a <code>TypeError</code>.
+ <li><p>If none of <var>options</var>' <code>childList</code>, <code>attributes</code>, and <code>characterData</code> is true, <a>throw</a> a <code>TypeError</code>.
 
- <li><p>If <var>options</var>' <code>attributeOldValue</code> is true and <var>options</var>' <code>attributes</code> is false, <a href="http://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a> a JavaScript <code>TypeError</code>.
+ <li><p>If <var>options</var>' <code>attributeOldValue</code> is true and <var>options</var>' <code>attributes</code> is false, <a>throw</a> a JavaScript <code>TypeError</code>.
 
- <li><p>If <var>options</var>' <code>attributeFilter</code> is present and <var>options</var>' <code>attributes</code> is false, <a href="http://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a> a JavaScript <code>TypeError</code>.
+ <li><p>If <var>options</var>' <code>attributeFilter</code> is present and <var>options</var>' <code>attributes</code> is false, <a>throw</a> a JavaScript <code>TypeError</code>.
 
- <li><p>If <var>options</var>' <code>characterDataOldValue</code> is true and <var>options</var>' <code>characterData</code> is false, <a href="http://www.w3.org/TR/WebIDL-1/#dfn-throw">throw</a> a JavaScript <code>TypeError</code>.
+ <li><p>If <var>options</var>' <code>characterDataOldValue</code> is true and <var>options</var>' <code>characterData</code> is false, <a>throw</a> a JavaScript <code>TypeError</code>.
 
  <li>
   <p>For each <a>registered observer</a> <var>registered</var> in <var>target</var>'s list of <a>registered observers</a> whose <b>observer</b> is the <a>context object</a>:
@@ -837,9 +832,9 @@ dictionary MutationObserverInit {
  <li><p>Otherwise, add a new <a>registered observer</a> to <var>target</var>'s list of <a>registered observers</a> with the <a>context object</a> as the <b>observer</b> and <var>options</var> as the <b>options</b>, and add <var>target</var> to <a>context object</a>'s list of <a>nodes</a> on which it is registered.
 </ol>
 
-<p>The <dfn><code>disconnect()</code></dfn> method must, for each <a>node</a> <var>node</var> in the <a>context object</a>'s list of <a>nodes</a>, remove any <a>registered observer</a> on <var>node</var> for which the <a>context object</a> is the <b>observer</b>, and also empty <a>context object</a>'s <a>record queue</a>.
+<p>The <dfn method for=MutationObserver><code>disconnect()</code></dfn> method, when invoked, must, for each <a href="#concept-node">node</a> <var>node</var> in the <a>context object</a>'s list of <a>nodes</a>, remove any <a>registered observer</a> on <var>node</var> for which the <a>context object</a> is the <b>observer</b>, and also empty <a>context object</a>'s <a>record queue</a>.
 
-<p>The <dfn><code>takeRecords()</code></dfn> method must return a copy of the <a>record queue</a> and then empty the <a>record queue</a>.
+<p>The <dfn method for=MutationObserver><code>takeRecords()</code></dfn> method, when invoked, must return a copy of the <a>record queue</a> and then empty the <a>record queue</a>.
 
 <h4 id="queuing-a-mutation-record">Queuing a mutation record</h4>
 <p>To <dfn>queue a mutation record</dfn> of <var>type</var> for <var>target</var> with one or more of (depends on <var>type</var>) name <var>name</var>, namespace <var>namespace</var>, oldValue <var>oldValue</var>, addedNodes <var>addedNodes</var>, removedNodes <var>removedNodes</var>, previousSibling <var>previousSibling</var>, and nextSibling <var>nextSibling</var>, run these steps:
@@ -884,17 +879,17 @@ dictionary MutationObserverInit {
   <ol>
    <li><p>Let <var>record</var> be a new <code> {{MutationRecord}} </code> object with its <code><a href="#mutationrecord-type">type</a></code> set to <var>type</var> and <code><a href="#mutationrecord-target">target</a></code> set to <var>target</var>.
 
-   <li><p>If <var>name</var> and <var>namespace</var> are given, set <var>record</var>'s <code><a>attributeName</a></code> to <var>name</var>, and <var>record</var>'s <code><a>attributeNamespace</a></code> to <var>namespace</var>.
+   <li><p>If <var>name</var> and <var>namespace</var> are given, set <var>record</var>'s <code>{{MutationRecord/attributeName}}</code> to <var>name</var>, and <var>record</var>'s <code>{{MutationRecord/attributeNamespace}}</code> to <var>namespace</var>.
 
-   <li><p>If <var>addedNodes</var> is given, set <var>record</var>'s <code><a>addedNodes</a></code> to <var>addedNodes</var>.
+   <li><p>If <var>addedNodes</var> is given, set <var>record</var>'s <code>{{MutationRecord/addedNodes}}</code> to <var>addedNodes</var>.
 
-   <li><p>If <var>removedNodes</var> is given, set <var>record</var>'s <code><a>removedNodes</a></code> to <var>removedNodes</var>,
+   <li><p>If <var>removedNodes</var> is given, set <var>record</var>'s <code>{{MutationRecord/removedNodes}}</code> to <var>removedNodes</var>,
 
-   <li><p>If <var>previousSibling</var> is given, set <var>record</var>'s <code><a href="#mutationrecord-previoussibling">previousSibling</a></code> to <var>previousSibling</var>.
+   <li><p>If <var>previousSibling</var> is given, set <var>record</var>'s <code>{{MutationRecord/previousSibling}}</code> to <var>previousSibling</var>.
 
-   <li><p>If <var>nextSibling</var> is given, set <var>record</var>'s <code><a href="#mutationrecord-nextsibling">nextSibling</a></code> to <var>nextSibling</var>.
+   <li><p>If <var>nextSibling</var> is given, set <var>record</var>'s <code>{{MutationRecord/nextSibling}}</code> to <var>nextSibling</var>.
 
-   <li><p>If <var>observer</var> has a paired string, set <var>record</var>'s <code><a>oldValue</a></code> to <var>observer</var>'s paired string.
+   <li><p>If <var>observer</var> has a paired string, set <var>record</var>'s <code>{{MutationRecord/oldValue}}</code> to <var>observer</var>'s paired string.
 
    <li><p>Append <var>record</var> to <var>observer</var>'s <a>record queue</a>.
   </ol>
@@ -902,7 +897,7 @@ dictionary MutationObserverInit {
  <li><p><a>Queue a mutation observer compound microtask</a>.
 </ol>
 
-<h4 id="interface-mutationrecord">Interface <code><a>MutationRecord</a></code></h4>
+<h4 id="interface-mutationrecord">Interface <code>{{MutationRecord}}</code></h4>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -920,43 +915,43 @@ interface MutationRecord {
 </pre>
 
 <dl>
- <dt><code><var>record</var> . <a href="#mutationrecord-type">type</a></code>
- <dd><p>Returns "<code>attributes</code>" if it was an <a href="#concept-attribute">attribute</a> mutation. "<code>characterData</code>" if it was a mutation to a <code><a>CharacterData</a></code> <a>node</a>. And "<code>childList</code>" if it was a mutation to the <a>tree</a> of <a>nodes</a>.
+ <dt><code><var>record</var> . {{MutationRecord/type}}</code>
+ <dd><p>Returns "<code>attributes</code>" if it was an <a href="#concept-attribute">attribute</a> mutation. "<code>characterData</code>" if it was a mutation to a <code>{{CharacterData}}</code> <a href="#concept-node">node</a>. And "<code>childList</code>" if it was a mutation to the <a>tree</a> of <a>nodes</a>.
 
- <dt><code><var>record</var> . <a href="#mutationrecord-target">target</a></code>
- <dd><p>Returns the <a>node</a> the mutation affected, depending on the <code><a href="#mutationrecord-type">type</a></code>. For "<code>attributes</code>", it is the <a>element</a> whose <a href="#concept-attribute">attribute</a> changed. For "<code>characterData</code>", it is the <code><a>CharacterData</a></code> <a>node</a>. For "<code>childList</code>", it is the  <a>node</a> whose <a>children</a> changed.
+ <dt><code><var>record</var> . {{MutationRecord/target}}</code>
+ <dd><p>Returns the <a href="#concept-node">node</a> the mutation affected, depending on the <code><a href="#mutationrecord-type">type</a></code>. For "<code>attributes</code>", it is the <a href="#concept-element">element</a> whose <a href="#concept-attribute">attribute</a> changed. For "<code>characterData</code>", it is the <code>{{CharacterData}}</code> <a href="#concept-node">node</a>. For "<code>childList</code>", it is the  <a href="#concept-node">node</a> whose <a>children</a> changed.
 
- <dt><code><var>record</var> . <a>addedNodes</a></code>
- <dt><code><var>record</var> . <a>removedNodes</a></code>
+ <dt><code><var>record</var> . {{MutationRecord/addedNodes}}</code>
+ <dt><code><var>record</var> . {{MutationRecord/removedNodes}}</code>
  <dd><p>Return the <a>nodes</a> added and removed respectively.
 
- <dt><code><var>record</var> . <a href="#mutationrecord-previoussibling">previousSibling</a></code>
- <dt><code><var>record</var> . <a href="#mutationrecord-nextsibling">nextSibling</a></code>
+ <dt><code><var>record</var> . {{MutationRecord/previousSibling}}</code>
+ <dt><code><var>record</var> . {{MutationRecord/nextSibling}}</code>
  <dd><p>Return the <a href="#tree-previous-sibling">previous</a> and <a href="#tree-next-sibling">next sibling</a> respectively of the added or removed <a>nodes</a>, and null otherwise.
 
- <dt><code><var>record</var> . <a>attributeName</a></code>
- <dd><p>Returns the <a>local name</a> of the changed <a href="#concept-attribute">attribute</a>, and null otherwise.
+ <dt><code><var>record</var> . {{MutationRecord/attributeName}}</code>
+ <dd><p>Returns the <a href="#attribute-local-name">local name</a> of the changed <a href="#concept-attribute">attribute</a>, and null otherwise.
 
- <dt><code><var>record</var> . <a>attributeNamespace</a></code>
- <dd><p>Returns the <a>namespace</a> of the changed <a href="#concept-attribute">attribute</a>, and null otherwise.
+ <dt><code><var>record</var> . {{MutationRecord/attributeNamespace}}</code>
+ <dd><p>Returns the <a href="#attribute-namespace">namespace</a> of the changed <a href="#concept-attribute">attribute</a>, and null otherwise.
 
- <dt><code><var>record</var> . <a>oldValue</a></code>
- <dd><p>The return value depends on <code><a href="#mutationrecord-type">type</a></code>. For "<code>attributes</code>", it is the <a href="#attribute-value">value</a> of the changed <a href="#concept-attribute">attribute</a> before the change. For "<code>characterData</code>", it is the <a href="#cd-data">data</a> of the changed <a>node</a> before the change. For "<code>childList</code>", it is null.
+ <dt><code><var>record</var> . {{MutationRecord/oldValue}}</code>
+ <dd><p>The return value depends on <code><a href="#mutationrecord-type">type</a></code>. For "<code>attributes</code>", it is the <a href="#attribute-value">value</a> of the changed <a href="#concept-attribute">attribute</a> before the change. For "<code>characterData</code>", it is the <a href="#cd-data">data</a> of the changed <a href="#concept-node">node</a> before the change. For "<code>childList</code>", it is null.
 </dl>
 
-<p>The <dfn id="mutationrecord-type" for="mutationrecord"><code>type</code></dfn> and <dfn id="mutationrecord-target" for="mutationrecord"><code>target</code></dfn> attributes must return the values they were initialized to.
+<p>The <dfn attribute id="mutationrecord-type" for=MutationRecord><code>type</code></dfn> attribute's getter and <dfn attribute id="mutationrecord-target" for=MutationRecord><code>target</code></dfn> attribute's getter must return the values they were initialized to.
 
-<p>The <dfn><code>addedNodes</code></dfn> and <dfn><code>removedNodes</code></dfn> attributes must return the values they were initialized to. Unless stated otherwise, when a <code><a>MutationRecord</a></code> object is created, they must both be initialized to an empty <code><a>NodeList</a></code>.
+<p>The <dfn attribute for=MutationRecord><code>addedNodes</code></dfn> attribute's getter and <dfn attribute for=MutationRecord><code>removedNodes</code></dfn> attribute's getter must return the values they were initialized to. Unless stated otherwise, when a <code>{{MutationRecord}}</code> object is created, they must both be initialized to an empty <code>{{NodeList}}</code>.
 
-<p>The <dfn id="mutationrecord-previoussibling" for="mutationrecord"><code>previousSibling</code></dfn>, <dfn id="mutationrecord-nextsibling" for="mutationrecord"><code>nextSibling</code></dfn>, <dfn><code>attributeName</code></dfn>, <dfn><code>attributeNamespace</code></dfn>, and <dfn>oldValue</code></dfn> attributes must return the values they were initialized to. Unless stated otherwise, when a <code><a>MutationRecord</a></code> object is created, they must be initialized to null.
+<p>The <dfn attribute id="mutationrecord-previoussibling" for=MutationRecord><code>previousSibling</code></dfn> attribute's getter, <dfn attribute id="mutationrecord-nextsibling" for=MutationRecord><code>nextSibling</code></dfn> attribute's getter, <dfn attribute for=MutationRecord><code>attributeName</code></dfn> attribute's gettr, <dfn attribute for=MutationRecord><code>attributeNamespace</code></dfn> attribute's getter, and <dfn attribute for=MutationRecord>oldValue</code></dfn> attribute's getter must return the values they were initialized to. Unless stated otherwise, when a <code>{{MutationRecord}}</code> object is created, they must be initialized to null.
 
 <h4 id="garbage-collection">Garbage collection</h4>
 
 <p><a>Nodes</a> have a strong reference to <a>registered observers</a> in their list of <a>registered observers</a>.
 
-<p><a>Registered observers</a> in a <a>node</a>'s list of <a>registered observers</a> have a weak reference to the <a>node</a>.
+<p><a>Registered observers</a> in a <a href="#concept-node">node</a>'s list of <a>registered observers</a> have a weak reference to the <a href="#concept-node">node</a>.
 
-<h3 id="nodes-interface-node">Interface <code><a href="#dom-node">Node</a></code></h3>
+<h3 id="nodes-interface-node">Interface <code>{{Node}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -993,7 +988,7 @@ interface Node : EventTarget {
   void normalize();
 
   [NewObject] Node cloneNode(optional boolean deep = false);
-  boolean isEqualNode(Node? node);
+  boolean isEqualNode(Node? other);
 
   const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
   const unsigned short DOCUMENT_POSITION_PRECEDING = 0x02;
@@ -1015,83 +1010,83 @@ interface Node : EventTarget {
 };
 </pre>
 
-<p class="note">Note: <code><dfn id="dom-node" for="dom">Node</dfn></code> is an abstract interface and does not exist as <a>node</a>. It is used by all <a>nodes</a> (<code><a>Document</a></code>, <code><a>DocumentFragment</a></code>, <code><a>DocumentType</a></code>, <code><a>Element</a></code>, <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, and <code><a>Comment</a></code>).
+<p class="note">Note: <code>{{Node}}</code> is an abstract interface and does not exist as <a href="#concept-node">node</a>. It is used by all <a>nodes</a> ({{Document}}, {{DocumentFragment}}, {{DocumentType}}, {{Element}}, {{Text}}, {{ProcessingInstruction}}, and {{Comment}}).
 
-<p>Each <a>node</a> has an associated <dfn>node document</dfn>, set upon creation, that is a <a>document</a>.
+<p>Each <a href="#concept-node">node</a> has an associated <dfn>node document</dfn>, set upon creation, that is a <a href="#concept-document">document</a>.
 
-<p class="note">Note: A <a>node</a>'s <a>node document</a> can be changed by the <a>adopt</a> algorithm.
+<p class="note">Note: A <a href="#concept-node">node</a>'s <a>node document</a> can be changed by the <a>adopt</a> algorithm.
 
 <hr>
 
 <dl>
- <dt><code><var>node</var> . <a>nodeType</a></code>
+ <dt><code><var>node</var> . {{Node/nodeType}}</code>
  <dd><p>Returns the type of <var>node</var>, represented by a number from the following list:</p>
 
   <dl>
-   <dt><code><a href="#dom-node">Node</a> . <a>ELEMENT_NODE</a></code> (1)
+   <dt><code>{{Node}} . {{Node/ELEMENT_NODE}}</code> (1)
    <dd><var>node</var> is an <a href="#concept-element">element</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>ATTRIBUTE_NODE</a></code> (2)
+   <dt><code>{{Node}} . {{Node/ATTRIBUTE_NODE}}</code> (2)
    <dd><var>node</var> is an <a href="#concept-attribute">attribute</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>TEXT_NODE</a></code> (3)
-   <dd><var>node</var> is a <code><a>Text</a></code> <a>node</a>.
+   <dt><code>{{Node}} . {{Node/TEXT_NODE}}</code> (3)
+   <dd><var>node</var> is a {{Text}} <a href="#concept-node">node</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>CDATA_SECTION_NODE</a></code> (4)
-   <dd><var>node</var> is a <code><a>CDATASection</a></code> <a>node</a>.
+   <dt><code>{{Node}} . {{Node/CDATA_SECTION_NODE}}</code> (4)
+   <dd><var>node</var> is a {{CDATASection}} <a href="#concept-node">node</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>PROCESSING_INSTRUCTION_NODE</a></code> (7)
-   <dd><var>node</var> is a <code><a>ProcessingInstruction</a></code> <a>node</a>.
+   <dt><code>{{Node}} . {{Node/PROCESSING_INSTRUCTION_NODE}}</code> (7)
+   <dd><var>node</var> is a {{ProcessingInstruction}} <a href="#concept-node">node</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>COMMENT_NODE</a></code> (8)
-   <dd><var>node</var> is a <code><a>Comment</a></code> <a>node</a>.
+   <dt><code>{{Node}} . {{Node/COMMENT_NODE}}</code> (8)
+   <dd><var>node</var> is a {{Comment}} <a href="#concept-node">node</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_NODE</a></code> (9)
-   <dd><var>node</var> is a <a>document</a>.
+   <dt><code>{{Node}} . {{Node/DOCUMENT_NODE}}</code> (9)
+   <dd><var>node</var> is a <a href="#concept-document">document</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_TYPE_NODE</a></code> (10)
-   <dd><var>node</var> is a <a>doctype</a>.
+   <dt><code>{{Node}} . {{Node/DOCUMENT_TYPE_NODE}}</code> (10)
+   <dd><var>node</var> is a <a href="#concept-doctype">doctype</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_FRAGMENT_NODE</a></code> (11)
-   <dd><var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>.
+   <dt><code>{{Node}} . {{Node/DOCUMENT_FRAGMENT_NODE}}</code> (11)
+   <dd><var>node</var> is a {{DocumentFragment}} <a href="#concept-node">node</a>.
   </dl>
 
- <dt><code><var>node</var> . nodeName</code>
+ <dt><code><var>node</var> . {{Node/nodeName}}</code>
  <dd>
   <p>Returns a string appropriate for the type of <var>node</var>, as
   follows:
 
   <dl>
-   <dt><code><a href="#element">Element</a></code>
-   <dd>Its <code><a>tagName</a></code> attribute value.
+   <dt><code>{{Element}}</code>
+   <dd>Its <code>{{Element/tagName}}</code> attribute value.
 
-   <dt><code><a href="#attr">Attr</a></code>
+   <dt><code>{{Attr}}</code>
    <dd>Its <code><a href="#attribute-qualified-name">qualified name</a></code>.
 
-   <dt><code><a>Text</a></code>
+   <dt><code>{{Text}}</code>
    <dd>"<code>#text</code>".
 
-   <dt><code><a>CDATASection</a></code>
+   <dt><code>{{CDATASection}}</code>
    <dd>"<code>#cdata-section</code>".
 
-   <dt><code><a>ProcessingInstruction</a></code>
+   <dt><code>{{ProcessingInstruction}}</code>
    <dd>Its <a href="#pi-target">target</a>.
 
-   <dt><code><a>Comment</a></code>
+   <dt><code>{{Comment}}</code>
    <dd>"<code>#comment</code>".
 
-   <dt><code><a>Document</a></code>
+   <dt><code>{{Document}}</code>
    <dd>"<code>#document</code>".
 
-   <dt><code><a>DocumentType</a></code>
+   <dt><code>{{DocumentType}}</code>
    <dd>Its <a href="#doctype-name">name</a>.
 
-   <dt><code><a>DocumentFragment</a></code>
+   <dt><code>{{DocumentFragment}}</code>
    <dd>"<code>#document-fragment</code>".
   </dl>
 </dl>
 
-<p>The <dfn><code>nodeType</code></dfn> attribute's getter, when invoked, must return the first matching statement, switching on the <a>context object</a>:
+<p>The <dfn attribute for=Node><code>nodeType</code></dfn> attribute's getter, when invoked, must return the first matching statement, switching on the <a>context object</a>:
 
 <dl class="switch">
  <dt>{{Element}}
@@ -1126,9 +1121,9 @@ interface Node : EventTarget {
 <!-- NodeExodus
 <hr>
 
-<p>The <dfn><code>namespaceURI</code></dfn> attribute must return the namespace that is associated with the node, if there is one and it's not the empty string, and null otherwise.
+<p>The <dfn><code>namespaceURI</code></dfn> attribute's getter must return the namespace that is associated with the node, if there is one and it's not the empty string, and null otherwise.
 
-<p>The <dfn id="node-prefix" for="node"><code>prefix</code></dfn> attribute must return the prefix that is associated with the node, if there is one and it's not the empty string, and null otherwise.
+<p>The <dfn id="node-prefix" for="node"><code>prefix</code></dfn> attribute's getter must return the prefix that is associated with the node, if there is one and it's not the empty string, and null otherwise.
 <!- - support setting? - - On setting, it must run these steps:
 
 <ol>
@@ -1142,79 +1137,78 @@ interface Node : EventTarget {
  <li><p>Actually this does not match any browser. Let's try to drop it instead.
 </ol>- ->
 
-<p>The <dfn><code>localName</code></dfn> attribute must return the local name that is associated with the node, if it has one, and null otherwise.-->
+<p>The <dfn><code>localName</code></dfn> attribute's getter must return the local name that is associated with the node, if it has one, and null otherwise.-->
 
-<p>The <code>nodeName</code> attribute's getter, when invoked, must return the first matching statement, switching on the <a href="#context-object">context object</a>:
+<p>The <dfn attribute for=Node><code>nodeName</code></a> attribute's getter must return the first matching statement, switching on the <a href="#context-object">context object</a>:
 
 <dl class="switch">
- <dt><code><a>Element</a></code>
- <dd><p>Its <code><a>tagName</a></code> attribute value.
+ <dt><code>{{Element}}</code>
+ <dd><p>Its <code>{{Element/tagName}}</code> attribute value.
 
- <dt><code><a href="#attr">Attr</a></code>
+ <dt><code>{{Attr}}</code>
  <dd>Its <code><a href="#attribute-qualified-name">qualified name</a></code>.
 
- <dt><code><a>Text</a></code>
+ <dt><code>{{Text}}</code>
  <dd><p>"<code>#text</code>".
 
- <dt><code><a>CDATASection</a></code>
+ <dt><code>{{CDATASection}}</code>
  <dd>"<code>#cdata-section</code>".
 
- <dt><code><a>ProcessingInstruction</a></code>
+ <dt><code>{{ProcessingInstruction}}</code>
  <dd><p>Its <a href="#pi-target">target</a>.
 
- <dt><code><a>Comment</a></code>
+ <dt><code>{{Comment}}</code>
  <dd><p>"<code>#comment</code>".
 
- <dt><code><a>Document</a></code>
+ <dt><code>{{Document}}</code>
  <dd><p>"<code>#document</code>".
 
- <dt><code><a>DocumentType</a></code>
+ <dt><code>{{DocumentType}}</code>
  <dd><p>Its <a href="#doctype-name">name</a>.
 
- <dt><code><a>DocumentFragment</a></code>
+ <dt><code>{{DocumentFragment}}</code>
  <dd><p>"<code>#document-fragment</code>".
 </dl>
 
 <hr>
 
 <dl>
- <dt><code><var>node</var> . baseURI</code>
- <dd><p>Returns <var>node</var>'s <a>node document</a>'s <a>base URL</a>.
+ <dt><code><var>node</var> . {{Node/baseURI}}</code>
+ <dd><p>Returns <var>node</var>'s <a>node document</a>'s <a>document base URL</a>.
 </dl>
 
-The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must return
-<a>node document</a>'s <a>base URL</a>.
+The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must return <a>node document</a>'s <a>document base URL</a>.
 
 <hr>
 
 <dl>
- <dt><code><var>node</var> . ownerDocument</code>
+ <dt><code><var>node</var> . {{Node/ownerDocument}}</code>
  <dd>
   <p>Returns the <a>node document</a>.
-  <p>Returns null for <a>documents</a>.
+  <p>Returns null for <a href="#concept-document">documents</a>.
 
- <dt><code><var>node</var> . <a>parentNode</a></code>
+ <dt><code><var>node</var> . {{Node/parentNode}}</code>
  <dd><p>Returns the <a>parent</a>.
 
- <dt><code><var>node</var> . <a>parentElement</a></code>
+ <dt><code><var>node</var> . {{Node/parentElement}}</code>
  <dd><p>Returns the <a>parent element</a>.
 
- <dt><code><var>node</var> . <a>hasChildNodes()</a></code>
+ <dt><code><var>node</var> . {{Node/hasChildNodes()}}</code>
  <dd><p>Returns whether <var>node</var> has <a href="#tree-child">children</a>.
 
- <dt><code><var>node</var> . <a>childNodes</a></code>
+ <dt><code><var>node</var> . {{Node/childNodes}}</code>
  <dd><p>Returns the <a href="#tree-child">children</a>.
 
- <dt><code><var>node</var> . <a>firstChild</a></code>
+ <dt><code><var>node</var> . {{Node/firstChild}}</code>
  <dd><p>Returns the <a>first child</a>.
 
- <dt><code><var>node</var> . <a>lastChild</a></code>
+ <dt><code><var>node</var> . {{Node/lastChild}}</code>
  <dd><p>Returns the <a>last child</a>.
 
- <dt><code><var>node</var> . <a href="#node-previoussibling">previousSibling</a></code>
+ <dt><code><var>node</var> . {{Node/previousSibling}}</code>
  <dd><p>Returns the <a href="#tree-previous-sibling">previous sibling</a>.
 
- <dt><code><var>node</var> . <a href="#node-nextsibling">nextSibling</a></code>
+ <dt><code><var>node</var> . {{Node/nextSibling}}</code>
  <dd><p>Returns the <a href="#tree-next-sibling">next sibling</a>.
 </dl>
 
@@ -1225,100 +1219,100 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must r
 
 <p class="note">The <a>node document</a> of a <a href="#concept-document">document</a> is that <a href="#concept-document">document</a> itself. All <a>nodes</a> have a <a href="#concept-document">document</a> at all times.
 
-<p>The <dfn><code>parentNode</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent</a>.
+<p>The <dfn attribute for=Node><code>parentNode</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent</a>.
 
 <p class="note">An {{Attr}} <a lt="nodes">node</a> has no <a>parent</a>.
 
-<p>The <dfn><code>parentElement</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent element</a>.
+<p>The <dfn attribute for=Node><code>parentElement</code></dfn> attribute's getter must return the <a>context object</a>'s <a>parent element</a>.
 
-<p>The <dfn><code>hasChildNodes()</code></dfn> method must return true if the <a>context object</a> has <a href="#tree-child">children</a>, and false otherwise.
+<p>The <dfn method for=Node><code>hasChildNodes()</code></dfn> method, when invoked, must return true if the <a>context object</a> has <a href="#tree-child">children</a>, and false otherwise.
 
-<p>The <dfn><code>childNodes</code></dfn> attribute's getter must return a <code>{{NodeList}}</code> rooted at the <a>context object</a> matching only <a>children</a>.
+<p>The <dfn attribute for=Node><code>childNodes</code></dfn> attribute's getter must return a <code>{{NodeList}}</code> rooted at the <a>context object</a> matching only <a>children</a>.
 
-<p>The <dfn><code>firstChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>first child</a>.
+<p>The <dfn attribute for=Node><code>firstChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>first child</a>.
 
-<p>The <dfn><code>lastChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>last child</a>.
+<p>The <dfn attribute for=Node><code>lastChild</code></dfn> attribute's getter must return the <a>context object</a>'s <a>last child</a>.
 
-<p>The <dfn id="node-previoussibling" for="node"><code>previousSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-previous-sibling">previous sibling</a>.
+<p>The <dfn attribute for=Node id="node-previoussibling"><code>previousSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-previous-sibling">previous sibling</a>.
 
 <p class="note">An {{Attr}} <a lt="nodes">node</a> has no <a>siblings</a>.
 
-<p>The <dfn id="node-nextsibling" for="node"><code>nextSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-next-sibling">next sibling</a>.
+<p>The <dfn attribute for=Node id="node-nextsibling"><code>nextSibling</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#tree-next-sibling">next sibling</a>.
 </div>
 
 <hr>
 
 <!-- TODO: domintro -->
 
-<p>The <dfn><code>nodeValue</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
+<p>The <dfn attribute for=Node><code>nodeValue</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
 
 <dl class="switch">
- <dt><code><a>Attr</a></code>
+ <dt><code>{{Attr}}</code>
  <dd><p><a>context object</a>'s <a href="#attribute-value">value</a>.
 
- <dt><code><a>Text</a></code>
- <dt><code><a>Comment</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{Comment}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
  <dd><p>The <a>context object</a>'s <a href="#cd-data">data</a>.
 
  <dt>Any other node
  <dd><p>Null.
 </dl>
 
-<p>The <code><a>nodeValue</a></code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
+<p>The <code>{{Node/nodeValue}}</code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class="switch">
- <dt><code><a>Attr</a></code>
+ <dt><code>{{Attr}}</code>
  <dd><p><a>Set an existing attribute value</a> with <a>context object</a> and new value.
 
- <dt><code><a>Text</a></code>
- <dt><code><a>Comment</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{Comment}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
  <dd><p><a>Replace data</a> with node <a>context object</a>, offset 0, count <a>context object</a>'s <a href="#node-length">length</a>, and data new value.
 
  <dt>Any other node
  <dd><p>Do nothing.
 </dl>
 
-<p>The <dfn id="event-textcontent" for="event"><code>textContent</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
+<p>The <dfn attribute id="event-textcontent" for=Node><code>textContent</code></dfn> attribute's getter must return the following, depending on the <a>context object</a>:
 
 <dl class="switch">
- <dt><code><a>DocumentFragment</a></code>
- <dt><code><a>Element</a></code>
- <dd><p>The concatenation of <a href="#cd-data">data</a> of all the <code><a>Text</a></code> <a>node</a> <a>descendants</a> of the <a>context object</a>, in <a>tree order</a>.
+ <dt><code>{{DocumentFragment}}</code>
+ <dt><code>{{Element}}</code>
+ <dd><p>The concatenation of <a href="#cd-data">data</a> of all the <code>{{Text}}</code> <a href="#concept-node">node</a> <a>descendants</a> of the <a>context object</a>, in <a>tree order</a>.
 
- <dt><code><a>Attr</a></code>
+ <dt><code>{{Attr}}</code>
  <dd><p><a>context object</a>'s <a href="#attribute-value">value</a>.
 
- <dt><code><a>Text</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
- <dt><code><a>Comment</a></code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
+ <dt><code>{{Comment}}</code>
  <dd><p>The <a>context object</a>'s <a href="#cd-data">data</a>.
 
  <dt>Any other node
  <dd><p>Null.
 </dl>
 
-<p>The <code><a href="#event-textcontent">textContent</a></code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
+<p>The <code>{{Node/textContent}}</code> attribute's setter must, if the new value is null, act as if it was the empty string instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class="switch">
- <dt><code><a>DocumentFragment</a></code>
- <dt><code><a>Element</a></code>
+ <dt><code>{{DocumentFragment}}</code>
+ <dt><code>{{Element}}</code>
  <dd>
   <ol>
    <li><p>Let <var>node</var> be null.
 
-   <li><p>If new value is not the empty string, set <var>node</var> to a new <code><a>Text</a></code> <a>node</a> whose <a href="#cd-data">data</a> is new value.
+   <li><p>If new value is not the empty string, set <var>node</var> to a new <code>{{Text}}</code> <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is new value.
 
    <li><p><a>Replace all</a> with <var>node</var> within the <a>context object</a>.
   </ol>
 
- <dt><code><a>Attr</a></code>
+ <dt><code>{{Attr}}</code>
  <dd><p><a>Set an existing attribute value</a> with <a>context object</a> and new value.
 
- <dt><code><a>Text</a></code>
- <dt><code><a>ProcessingInstruction</a></code>
- <dt><code><a>Comment</a></code>
+ <dt><code>{{Text}}</code>
+ <dt><code>{{ProcessingInstruction}}</code>
+ <dt><code>{{Comment}}</code>
  <dd><p><a>Replace data</a> with node <a>context object</a>, offset 0, count <a>context object</a>'s <a href="#node-length">length</a>, and data new value.
 
  <dt>Any other node
@@ -1328,7 +1322,7 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must r
 <hr>
 
 <dl>
- <dt><code><var>node</var> . <a>normalize</a>()</code>
+ <dt><code><var>node</var> . {{Node/normalize()}}</code>
  <dd><p>Removes <a>empty</a> <code><a>exclusive <code>Text</code> nodes</a> and concatenates the <a href="#cd-data">data</a> of remaining <a>contiguous exclusive <code>Text</code> nodes</a> into the first of their <a>nodes</a>.
 </dl>
 
@@ -1339,7 +1333,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 <ol>
  <li>Let <var>length</var> be <var>node</var>'s <a href="#node-length">length</a>.
 
- <li>If <var>length</var> is zero, then <a>remove</a> <var>node</var> and continue with the next
+ <li>If <var>length</var> is zero, then <a href="#node-remove">remove</a> <var>node</var> and continue with the next
  <a>exclusive <code>Text</code> node</a>, if any.
 
  <li>Let <var>data</var> be the concatenation of the <a href="#cd-data">data</a> of
@@ -1355,20 +1349,20 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   <p>While <var>currentNode</var> is an <a>exclusive <code>Text</code> node</a>:
 
   <ol>
-   <li><p>For each <a>range</a> whose <a for=Range>start node</a> is <var>currentNode</var>, add
+   <li><p>For each <a href="#concept-range">range</a> whose <a for=Range>start node</a> is <var>currentNode</var>, add
    <var>length</var> to its <a>start offset</a> and set its <a for=Range>start node</a> to
    <var>node</var>.
 
-   <li><p>For each <a>range</a> whose <a for=Range>end node</a> is <var>currentNode</var>, add
+   <li><p>For each <a href="#concept-range">range</a> whose <a for=Range>end node</a> is <var>currentNode</var>, add
    <var>length</var> to its <a>end offset</a> and set its <a for=Range>end node</a> to
    <var>node</var>.
 
-   <li><p>For each <a>range</a> whose <a for=Range>start node</a> is <var>currentNode</var>'s
+   <li><p>For each <a href="#concept-range">range</a> whose <a for=Range>start node</a> is <var>currentNode</var>'s
    <a for=tree>parent</a> and <a>start offset</a> is <var>currentNode</var>'s <a for=tree>index</a>,
    set its <a for=Range>start node</a> to <var>node</var> and its <a>start offset</a> to
    <var>length</var>.
 
-   <li><p>For each <a>range</a> whose <a for=Range>end node</a> is <var>currentNode</var>'s
+   <li><p>For each <a href="#concept-range">range</a> whose <a for=Range>end node</a> is <var>currentNode</var>'s
    <a for=tree>parent</a> and <a>end offset</a> is <var>currentNode</var>'s <a for=tree>index</a>,
    set its <a for=Range>end node</a> to <var>node</var> and its <a>end offset</a> to
    <var>length</var>.
@@ -1378,16 +1372,16 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    <li><p>Set <var>currentNode</var> to its <a for=tree>next sibling</a>.
   </ol>
 
- <li><a>Remove</a> <var>node</var>'s <a>contiguous exclusive <code>Text</code> nodes</a> (excluding
+ <li><a href="#node-remove">Remove</a> <var>node</var>'s <a>contiguous exclusive <code>Text</code> nodes</a> (excluding
  itself), in <a>tree order</a>.
 </ol>
 <hr>
 
 <dl>
- <dt><code><var>node</var> . <a>cloneNode</a>([<var>deep</var> = false])</code>
+ <dt><code><var>node</var> . <a method for=Node lt=cloneNode()>cloneNode([<var>deep</var> = false])</a></code>
  <dd><p>Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>'s <a>descendants</a>.
 
- <dt><code><var>node</var> . <a>isEqualNode</a>(<var>other</var>)</code>
+ <dt><code><var>node</var> . {{Node/isEqualNode(other)}}</code>
  <dd><p>Returns whether <var>node</var> and <var>other</var> have the same properties.
 </dl>
 
@@ -1395,9 +1389,9 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
 <p><a>Specifications</a> may define <dfn>cloning steps</dfn> for all or some <a>nodes</a>. The algorithm is passed <var>copy</var>, <var>node</var>, <var>document</var>, and an optional <i>clone children flag</i>, as indicated in the <a href="#node-clone">clone</a> algorithm.
 
-<p class="note">Note: HTML defines <a>cloning steps</a> for <code><a href="http://www.w3.org/TR/html5/scripting-1.html#the-script-element">script</a></code> and <code><a href="http://www.w3.org/TR/html5/forms.html#the-input-element">input</a></code> elements. SVG ought to do the same for its <code>script</code> elements, but does not call this out at the moment.
+<p class="note">Note: HTML defines <a>cloning steps</a> for <code><a>script</a></code> and <code><a>input</a></code> elements. SVG ought to do the same for its <code>script</code> elements, but does not call this out at the moment.
 
-<p>To <dfn id="node-clone" for="node">clone</dfn> a <var>node</var>, with an optional <var>document</var> and <i>clone children flag</i>, run these steps:
+<p>To <dfn id="node-clone">clone</dfn> a <var>node</var>, with an optional <var>document</var> and <i>clone children flag</i>, run these steps:
 
 <ol>
  <li><p>If <var>document</var> is not given, let <var>document</var> be <var>node</var>'s <a>node document</a>.
@@ -1411,7 +1405,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    <a href="#element-namespace-prefix">namespace prefix</a>, to those of <var>node</var>.
    <li>
     <p>For each <var>attribute</var> in <var>node</var>'s
-    <a>attribute list</a>, in order, run these substeps:
+    <a for=Element>attribute list</a>, in order, run these substeps:
 
     <ol>
      <li><p>Let <var>copyAttribute</var> be a <a>clone</a> of <var>attribute</var>.
@@ -1428,10 +1422,10 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
   <dl>
    <dt>{{Document}}
-   <dd><p>Set <var>copy</var>'s <a href="#document-encoding">encoding</a>,
-   <a href="#concept-document-content-type">content type</a>, <a href="#document-url">URL</a>,
+   <dd><p>Set <var>copy</var>'s <a href="#concept-document-encoding">encoding</a>,
+   <a href="#concept-document-content-type">content type</a>, <a href="#concept-document-url">URL</a>,
    <a href="#concept-document-origin">origin</a>,
-   <a href="#dom-document-doctype">type</a>, and <a href="#dom-document-compatmode">mode</a>,
+   <a href="#concept-document-type">type</a>, and <a href="#dom-document-compatmode">mode</a>,
    to those of <var>node</var>.
 
    <dt>{{DocumentType}}
@@ -1454,7 +1448,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   </dl>
 
  <li><p>Set <var>copy</var>'s <a>node document</a> and <var>document</var> to
- <var>copy</var>, if <var>copy</var> is a <a>document</a>, and set <var>copy</var>'s
+ <var>copy</var>, if <var>copy</var> is a <a href="#concept-document">document</a>, and set <var>copy</var>'s
  <a>node document</a> to <var>document</var> otherwise.
 
  <li><p>Run any <a>cloning steps</a> defined for <var>node</var> in <a>other applicable specifications</a> and pass <var>copy</var>, <var>node</var>, <var>document</var> and the <i>clone children flag</i> if set, as parameters.
@@ -1464,66 +1458,66 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
  <li><p>Return <var>copy</var>.
 </ol>
 
-<p>The <dfn><code>cloneNode(<var>deep</var>)</code></dfn> method must return a <a href="#node-clone">clone</a> of the <a>context object</a>, with the <i>clone children flag</i> set if <var>deep</var> is true.
+<p>The <dfn method for=Node><code>cloneNode(<var>deep</var>)</code></dfn> method, when invoked, must return a <a href="#node-clone">clone</a> of the <a>context object</a>, with the <i>clone children flag</i> set if <var>deep</var> is true.
 
-<p>A <a>node</a> <var>A</var> <dfn>equals</dfn> a <a>node</a> <var>B</var> if all of the following conditions are true:
+<p>A <a href="#concept-node">node</a> <var>A</var> <dfn>equals</dfn> a <a href="#concept-node">node</a> <var>B</var> if all of the following conditions are true:
 
 <ul>
- <li><p><var>A</var> and <var>B</var>'s <code><a>nodeType</a></code> attribute value is identical.
+ <li><p><var>A</var> and <var>B</var>'s <code>{{Node/nodeType}}</code> attribute value is identical.
  <li>
   <p>The following are also equal, depending on <var>A</var>:
   <dl class="switch">
-   <dt><code><a>DocumentType</a></code>
+   <dt><code>{{DocumentType}}</code>
    <dd><p>Its <a href="#doctype-name">name</a>, <a>public ID</a>, and <a>system ID</a>.
 
-   <dt><code><a>Element</a></code>
+   <dt><code>{{Element}}</code>
    <dd>
-    <p>Its <a href="#element-namespace">namespace</a>, <a href="#element-namespace-prefix">namespace prefix</a>, <a href="#element-local-name">local name</a>, and its number of <a href="#concept-attribute">attributes</a> in its <a>attribute list</a>.
+    <p>Its <a href="#element-namespace">namespace</a>, <a href="#element-namespace-prefix">namespace prefix</a>, <a href="#element-local-name">local name</a>, and its number of <a href="#concept-attribute">attributes</a> in its <a for=Element>attribute list</a>.
 
-   <dt><code><a>Attr</a></code>
+   <dt><code>{{Attr}}</code>
    <dd><p>Its <a href="#attribute-namespace">namespace</a>, <a href="#attribute-local-name">local name</a>, and <a href="#attribute-value">value</a>.
 
 
-   <dt><code><a>ProcessingInstruction</a></code>
+   <dt><code>{{ProcessingInstruction}}</code>
    <dd><p>Its <a href="#pi-target">target</a> and <a href="#cd-data">data</a>.
 
-   <dt><code><a>Text</a></code>
-   <dt><code><a>Comment</a></code>
+   <dt><code>{{Text}}</code>
+   <dt><code>{{Comment}}</code>
    <dd><p>Its <a href="#cd-data">data</a>.
 
    <dt>Any other node
    <dd><p>—
   </dl>
- <li><p>If <var>A</var> is an <a>element</a>, each <a href="#concept-attribute">attribute</a> in its <a>attribute list</a> has an <a href="#concept-attribute">attribute</a> that <a>equals</a> in <var>B</var>'s <a>attribute list</a>.
+ <li><p>If <var>A</var> is an <a href="#concept-element">element</a>, each <a href="#concept-attribute">attribute</a> in its <a for=Element>attribute list</a> has an <a href="#concept-attribute">attribute</a> that <a>equals</a> in <var>B</var>'s <a for=Element>attribute list</a>.
  <li><p><var>A</var> and <var>B</var> have the same number of <a href="#tree-child">children</a>.
  <li><p>Each <a href="#tree-child">child</a> of <var>A</var> <a>equals</a> the <a href="#tree-child">child</a> of <var>B</var> at the identical <a>index</a>.
 </ul>
 
-<p>The <dfn><code>isEqualNode(<var>node</var>)</code></dfn> method must return true if <var>node</var> is not null and <a>context object</a> <a>equals</a> <var>node</var>, and false otherwise.
+<p>The <dfn method for=Node><code>isEqualNode(<var>other</var>)</code></dfn> method, when invoked, must return true if <var>other</var> is not null and <a>context object</a> <a>equals</a> <var>other</var>, and false otherwise.
 
 </div>
 
 <hr>
 
 <dl>
- <dt><code><var>node</var> . <a>compareDocumentPosition</a>(<var>other</var>)</code>
+ <dt><code><var>node</var> . {{Node/compareDocumentPosition(other)}}</code>
  <dd>
   <p>Returns a bitmask indicating the position of <var>other</var> relative to <var>node</var>. These are the bits that can be set:
 
   <dl>
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_POSITION_DISCONNECTED</a></code> (1)
+   <dt><code>{{Node}} . <a>DOCUMENT_POSITION_DISCONNECTED</a></code> (1)
    <dd>Set when <var>node</var> and <var>other</var> are not in the same <a>tree</a>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_POSITION_PRECEDING</a></code> (2)
+   <dt><code>{{Node}} . <a>DOCUMENT_POSITION_PRECEDING</a></code> (2)
    <dd>Set when <var>other</var> is <a>preceding</a> <var>node</var>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_POSITION_FOLLOWING</a></code> (4)
+   <dt><code>{{Node}} . <a>DOCUMENT_POSITION_FOLLOWING</a></code> (4)
    <dd>Set when <var>other</var> is <a>following</a> <var>node</var>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_POSITION_CONTAINS</a></code> (8)
+   <dt><code>{{Node}} . <a>DOCUMENT_POSITION_CONTAINS</a></code> (8)
    <dd>Set when <var>other</var> is an <a>ancestor</a> of <var>node</var>.
 
-   <dt><code><a href="#dom-node">Node</a> . <a>DOCUMENT_POSITION_CONTAINED_BY</a></code> (16, 10 in hexadecimal)
+   <dt><code>{{Node}} . <a>DOCUMENT_POSITION_CONTAINED_BY</a></code> (16, 10 in hexadecimal)
    <dd>Set when <var>other</var> is a <a>descendant</a> of <var>node</var>.
   </dl>
 
@@ -1542,7 +1536,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
  <li><dfn><code>DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</code></dfn> (32, 20 in hexadecimal).
 </ul>
 
-<p>The <dfn><code>compareDocumentPosition(<var>other</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Node><code>compareDocumentPosition(<var>other</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <a>context object</a> is <var>other</var>, then return zero.
@@ -1551,11 +1545,11 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
  <li><p>Let <var>attr1</var> and <var>attr2</var> be null.
 
- <li><p>If <var>node1</var> is an <a>attribute</a>, then set <var>attr1</var> to <var>node1</var>
+ <li><p>If <var>node1</var> is an <a href="#concept-attribute">attribute</a>, then set <var>attr1</var> to <var>node1</var>
  and <var>node1</var> to <var>attr1</var>'s <a href="#concept-element">element</a>.
 
  <li>
-  <p>If <var>node2</var> is an <a>attribute</a>, then:
+  <p>If <var>node2</var> is an <a href="#concept-attribute">attribute</a>, then:
 
   <ol>
    <li><p>Set <var>attr2</var> to <var>node2</var> and <var>node2</var> to <var>attr2</var>'s
@@ -1567,8 +1561,8 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
     <ol>
      <li>
-      <p>For each <a>attribute</a> <var>attr</var> in <var>node2</var>'s
-      <a>attribute list</a>:
+      <p>For each <a href="#concept-attribute">attribute</a> <var>attr</var> in <var>node2</var>'s
+      <a for=Element>attribute list</a>:
 
       <ol>
        <li><p>If <var>attr</var> <a>equals</a> <var>attr1</var>, then return the result of
@@ -1583,8 +1577,8 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   </ol>
 
  <li>
-  <p>If <var>node1</var> or <var>node2</var> is null, or <var>node1</var>'s <a>root</a> is
-  not <var>node2</var>'s <a>root</a>, then return the result of adding
+  <p>If <var>node1</var> or <var>node2</var> is null, or <var>node1</var>'s <a href="#tree-root">root</a> is
+  not <var>node2</var>'s <a href="#tree-root">root</a>, then return the result of adding
   {{Node/DOCUMENT_POSITION_DISCONNECTED}}, {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}}, and
   either {{Node/DOCUMENT_POSITION_PRECEDING}} or {{Node/DOCUMENT_POSITION_FOLLOWING}}, with the
   constraint that this is to be consistent, together.
@@ -1606,14 +1600,14 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   <p>If <var>node1</var> is <a>preceding</a> <var>node2</var>, then return
   {{Node/DOCUMENT_POSITION_PRECEDING}}.
 
-  <p class="note">Due to the way <a>attributes</a> are handled in this algorithm this results in a
-  <a>node</a>'s <a>attributes</a> counting as <a>preceding</a> that <a>node</a>'s <a>children</a>,
-  despite <a>attributes</a> not <a>participating</a> in a <a>tree</a>.
+  <p class="note">Due to the way <a href="#concept-attribute">attributes</a> are handled in this algorithm this results in a
+  <a href="#concept-node">node</a>'s <a href="#concept-attribute">attributes</a> counting as <a>preceding</a> that <a href="#concept-node">node</a>'s <a>children</a>,
+  despite <a href="#concept-attribute">attributes</a> not <a>participating</a> in a <a>tree</a>.
 
  <li><p>Return <code><a>DOCUMENT_POSITION_FOLLOWING</a></code>.
 </ol>
 
-<p>The <dfn id="node-contains-func" for="node"><code>contains(<var>other</var>)</code></dfn> method, when invoked, must return true if <var>other</var> is an <a>inclusive descendant</a> of <a>context object</a>, and false otherwise (including when <var>other</var> is null).
+<p>The <dfn method id="node-contains-func" for=Node><code>contains(<var>other</var>)</code></dfn> method, when invoked, must return true if <var>other</var> is an <a>inclusive descendant</a> of <a>context object</a>, and false otherwise (including when <var>other</var> is null).
 
 <hr>
 
@@ -1630,14 +1624,14 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
  <li><p>If, <var>element</var> <a>has</a> an <a href="#concept-attribute">attribute</a> whose <a href="#attribute-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <a href="#attribute-value">value</a> is <var>namespace</var>, then return <var>element</var>'s first such <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a>.
 
- <li><p>If <var>element</var>'s <a>parent element</a> is not null, then return the result of running <a>locate a namespace prefix</a> on that <a>element</a> using <var>namespace</var>. <li><p>Return null.
+ <li><p>If <var>element</var>'s <a>parent element</a> is not null, then return the result of running <a>locate a namespace prefix</a> on that <a href="#concept-element">element</a> using <var>namespace</var>. <li><p>Return null.
 
 </ol>
 
 <p>To <dfn>locate a namespace</dfn> for a <var>node</var> using <var>prefix</var> switch on <var>node</var>:
 
 <dl class="switch">
- <dt><code><a href="#dom-element">Element</a></code>
+ <dt><code>{{Element}}</code>
  <dd>
   <ol>
    <li><p>If its <a href="#element-namespace">namespace</a> is not null and its <a href="#element-namespace-prefix">namespace prefix</a> is <var>prefix</var>, then return <a href="#element-namespace">namespace</a>.
@@ -1655,7 +1649,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    <li><p>Return the result of running <a>locate a namespace</a> on its <a>parent element</a> using <var>prefix</var>.
   </ol>
 
- <dt><code><a>Document</a></code>
+ <dt><code>{{Document}}</code>
  <dd>
   <ol>
    <li><p>If its <a>document element</a> is null, then return null.
@@ -1663,16 +1657,16 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    <li><p>Return the result of running <a>locate a namespace</a> on its <a>document element</a> using <var>prefix</var>.
   </ol>
 
- <dt><code><a>DocumentType</a></code>
- <dt><code><a>DocumentFragment</a></code>
+ <dt><code>{{DocumentType}}</code>
+ <dt><code>{{DocumentFragment}}</code>
  <dd><p>Return null.
 
  <dt>{{Attr}}
  <dd>
   <ol>
-   <li><p>If its <a>element</a> is null, then return null.
+   <li><p>If its <a href="#concept-element">element</a> is null, then return null.
 
-   <li><p>Return the result of running <a>locate a namespace</a> on its <a>element</a>
+   <li><p>Return the result of running <a>locate a namespace</a> on its <a href="#concept-element">element</a>
    using <var>prefix</var>.
   </ol>
 
@@ -1685,7 +1679,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   </ol>
 </dl>
 
-<p>The <dfn><code>lookupPrefix(<var>namespace</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=Node><code>lookupPrefix(<var>namespace</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>namespace</var> is null or the empty string, then return null.
@@ -1694,14 +1688,14 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   <p>Switch on the <a>context object</a>:
 
   <dl class="switch">
-   <dt><code><a href="#dom-element">Element</a></code>
+   <dt><code>{{Element}}</code>
    <dd><p>Return the result of <a lt="locate a namespace prefix">locating a namespace prefix</a> for it using <var>namespace</var>.
 
-   <dt><code><a>Document</a></code>
+   <dt><code>{{Document}}</code>
    <dd><p>Return the result of <a lt="locate a namespace prefix">locating a namespace prefix</a> for its <a>document element</a>, if its <a>document element</a> is non-null, and null otherwise.
 
-   <dt><code><a>DocumentType</a></code>
-   <dt><code><a>DocumentFragment</a></code>
+   <dt><code>{{DocumentType}}</code>
+   <dt><code>{{DocumentFragment}}</code>
    <dd><p>Return null.
 
    <dt>{{Attr}}
@@ -1713,7 +1707,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    </dl>
 </ol>
 
-<p>The <dfn><code>lookupNamespaceURI(<var>prefix</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=Node><code>lookupNamespaceURI(<var>prefix</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>prefix</var> is the empty string, then set it to null.
@@ -1721,7 +1715,7 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
  <li><p>Return the result of running <a>locate a namespace</a> for the <a>context object</a> using <var>prefix</var>.
 </ol>
 
-<p>The <dfn><code>isDefaultNamespace(<var>namespace</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=Node><code>isDefaultNamespace(<var>namespace</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>namespace</var> is the empty string, then set it to null.
@@ -1733,20 +1727,20 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
 
 <hr>
 
-<p>The <dfn><code>insertBefore(<var>node</var>, <var>child</var>)</code></dfn> method, when invoked, must return the result of <a>pre-inserting</a> <var>node</var> into <a>context object</a> before <var>child</var>.
+<p>The <dfn method for=Node><code>insertBefore(<var>node</var>, <var>child</var>)</code></dfn> method, when invoked, must return the result of <a>pre-inserting</a> <var>node</var> into <a>context object</a> before <var>child</var>.
 
-<p>The <dfn><code>appendChild(<var>node</var>)</code></dfn> method, when invoked, must return the result of <a>appending</a> <var>node</var> to <a>context object</a>.
+<p>The <dfn method for=Node><code>appendChild(<var>node</var>)</code></dfn> method, when invoked, must return the result of <a href="#node-append">appending</a> <var>node</var> to <a>context object</a>.
 
-<p>The <dfn><code>replaceChild(<var>node</var>, <var>child</var>)</code></dfn> method, when invoked, must return the result of <a href="#node-replace">replacing</a> <var>child</var> with <var>node</var> within <a>context object</a>.
+<p>The <dfn method for=Node><code>replaceChild(<var>node</var>, <var>child</var>)</code></dfn> method, when invoked, must return the result of <a href="#node-replace">replacing</a> <var>child</var> with <var>node</var> within <a>context object</a>.
 
-<p>The <dfn><code>removeChild(<var>child</var>)</code></dfn> method, when invoked, must return the result of <a>pre-removing</a> <var>child</var> from <a>context object</a>.
+<p>The <dfn method for=Node><code>removeChild(<var>child</var>)</code></dfn> method, when invoked, must return the result of <a>pre-removing</a> <var>child</var> from <a>context object</a>.
 
-<p>The <dfn>list of elements with local name <var>localName</var></dfn> for a <a>node</a> <var>root</var> is the <code><a>HTMLCollection</a></code> returned by the following algorithm:
+<p>The <dfn>list of elements with local name <var>localName</var></dfn> for a <a href="#concept-node">node</a> <var>root</var> is the <code>{{HTMLCollection}}</code> returned by the following algorithm:
 <ol>
- <li><p>If <var>localName</var> is "<code>*</code>" (U+002A), return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches only <a>elements</a>.
+ <li><p>If <var>localName</var> is "<code>*</code>" (U+002A), return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches only <a>elements</a>.
 
  <li>
-  <p>Otherwise, if <var>root</var>'s <a>node document</a> is an <a>HTML document</a>, return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches the following <a>descendant</a> <a>elements</a>:
+  <p>Otherwise, if <var>root</var>'s <a>node document</a> is an <a>HTML document</a>, return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches the following <a>descendant</a> <a>elements</a>:
 
   <ul>
    <li>Whose <a href="#element-namespace">namespace</a> is the <a>HTML namespace</a> and whose <a href="#element-local-name">local name</a> is <var>localName</var> <a>converted to ASCII lowercase</a>.
@@ -1754,47 +1748,47 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
    <li>Whose <a href="#element-namespace">namespace</a> is <em>not</em> the <a>HTML namespace</a> and whose <a href="#element-local-name">local name</a> is <var>localName</var>.
   </ul>
 
- <li><p>Otherwise, return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
+ <li><p>Otherwise, return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
 </ol>
 
 <p>When invoked with the same argument, and as long as <var>root</var>'s <a>node document</a>'s <a for=Document>type</a> has not changed,
 the same <code>{{HTMLCollection}}</code> object may be returned as returned by an earlier call.
 
 
-<p>The <dfn>list of elements with namespace <var>namespace</var> and local name <var>localName</var></dfn> for a <a>node</a> <var>root</var> is the <code><a>HTMLCollection</a></code> returned by the following algorithm:
+<p>The <dfn>list of elements with namespace <var>namespace</var> and local name <var>localName</var></dfn> for a <a href="#concept-node">node</a> <var>root</var> is the <code>{{HTMLCollection}}</code> returned by the following algorithm:
 
 <ol>
  <li><p>If <var>namespace</var> is the empty string, set it to null.
 
- <li><p>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a>.
+ <li><p>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a>.
 
- <li><p>Otherwise, if <var>namespace</var> is "<code>*</code>" (U+002A), return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
+ <li><p>Otherwise, if <var>namespace</var> is "<code>*</code>" (U+002A), return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
 
- <li><p>Otherwise, if <var>localName</var> is "<code>*</code>" (U+002A), return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var>.
+ <li><p>Otherwise, if <var>localName</var> is "<code>*</code>" (U+002A), return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var>.
 
- <li><p>Otherwise, return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var> and <a href="#element-local-name">local name</a> is <var>localName</var>.
+ <li><p>Otherwise, return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var> and <a href="#element-local-name">local name</a> is <var>localName</var>.
 </ol>
 
 <p>When invoked with the same arguments, the same <code>{{HTMLCollection}}</code> object may be returned as returned by an earlier call.
 
 
-<p>The <dfn>list of elements with class names <var>classNames</var></dfn> for a <a>node</a> <var>root</var> is the <code><a>HTMLCollection</a></code> returned by the following algorithm:
+<p>The <dfn>list of elements with class names <var>classNames</var></dfn> for a <a href="#concept-node">node</a> <var>root</var> is the <code>{{HTMLCollection}}</code> returned by the following algorithm:
 <ol>
  <li>
   <p>Let <var>classes</var> be the result of running the <a>ordered set parser</a> on <var>classNames</var>.
 
  <li>
-  <p>If <var>classes</var> is the empty set, return an empty <code><a>HTMLCollection</a></code>.
+  <p>If <var>classes</var> is the empty set, return an empty <code>{{HTMLCollection}}</code>.
 
  <li>
-  <p>Return a <code><a>HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> that have all their <a>classes</a> in <var>classes</var>.
+  <p>Return a <code>{{HTMLCollection}}</code> rooted at <var>root</var>, whose filter matches <a>descendant</a> <a>elements</a> that have all their <a>classes</a> in <var>classes</var>.
 
   <p>The comparisons for the <a>classes</a> must be done in an <a>ASCII case-insensitive</a> manner if <var>root</var>'s <a>node document</a>'s <a for=Document>mode</a> is "<code>quirks</code>", and in a <a>case-sensitive</a> manner otherwise.
 </ol>
 
 <p>When invoked with the same argument, the same <code>{{HTMLCollection}}</code> object may be returned as returned by an earlier call.
 
-<h3 id="nodes-interface-document">Interface <code><a href="#dom-document">Document</a></code></h3>
+<h3 id="nodes-interface-document">Interface <code>{{Document}}</code></h3>
 
 <pre class='idl'>
 [Constructor,
@@ -1843,110 +1837,110 @@ interface Document : Node {
 interface XMLDocument : Document {};
 </pre>
 
-<p><code><dfn id="dom-document" for="dom">Document</dfn></code> <a>nodes</a> are simply known as <dfn for="concept" lt="document|documents">documents</dfn>.
+<p><code>{{Document}}</code> <a>nodes</a> are simply known as <dfn id="concept-document" for="concept" lt="document|documents">documents</dfn>.
 
-<p>Each <a>document</a> has an associated <dfn export for=Document id=document-encoding>encoding</dfn> (an <a spec=encoding>encoding</a>), <dfn export for=Document id=concept-document-content-type>content type</dfn> (a string), <dfn export for=Document id=concept-document-url>URL</dfn> (a <a spec=url>URL</a>), <dfn export for=Document id=concept-document-origin>origin</dfn> (an <a spec=HTML51>origin</a>),
+<p>Each <a href="#concept-document">document</a> has an associated <dfn export id="concept-document-encoding" for=Document>encoding</dfn> (an <a spec=encoding>encoding</a>), <dfn export for=Document id=concept-document-content-type>content type</dfn> (a string), <dfn export for=Document id=concept-document-url>URL</dfn> (a <a spec=url>URL</a>), <dfn export for=Document id=concept-document-origin>origin</dfn> (an <a spec=HTML51>origin</a>),
 <dfn export for=Document id=concept-document-type>type</dfn> ("<code>xml</code>" or "<code>html</code>"), and <dfn export for=Document id=concept-document-mode>mode</dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>"). [[!ENCODING]] [[!URL]] [[!HTML51]]
 
-<p>Unless stated otherwise, a <a>document</a>'s <a href="#document-encoding">encoding</a> is the <a>utf-8</a> <a spec=encoding>encoding</a>, its <a for=Document>content type</a> is "<code>application/xml</code>", its <a for=Document" title="document-url">URL</a> is "<code>about:blank</code>", <a for=Document>origin</a> is an <code><a>opaque origin</a></code>, <a for=Document>type</a> is "<code>xml</code>", and its <a for=Document>mode</a> is "<code>no-quirks</code>".
+<p>Unless stated otherwise, a <a href="#concept-document">document</a>'s <a href="#concept-document-encoding">encoding</a> is the <a>utf-8</a> <a spec=encoding>encoding</a>, its <a for=Document>content type</a> is "<code>application/xml</code>", its <a href="#concept-document-url" for=Document>URL</a> is "<code>about:blank</code>", <a for=Document>origin</a> is an <code><a>opaque origin</a></code>, <a for=Document>type</a> is "<code>xml</code>", and its <a for=Document>mode</a> is "<code>no-quirks</code>".
 
-<p>A <a>document</a> is said to be an <dfn export>XML document</dfn> if its <a for=Document>type</a> is "<code>xml</code>", and an <dfn>HTML document</dfn> otherwise. Whether a <a>document</a> is an <a>HTML document</a> or an <a>XML document</a> affects the behavior of certain APIs.
+<p>A <a href="#concept-document">document</a> is said to be an <dfn export>XML document</dfn> if its <a for=Document>type</a> is "<code>xml</code>", and an <dfn>HTML document</dfn> otherwise. Whether a <a href="#concept-document">document</a> is an <a>HTML document</a> or an <a>XML document</a> affects the behavior of certain APIs.
 
-A <a>document</a> is said to be in <dfn export id=concept-document-no-quirks>no-quirks mode</dfn> if its <a for=Document>mode</a> is "<code>no-quirks</code>", <dfn export id=concept-document-quirks>quirks mode</dfn> if its <a for=Document>mode</a> is "<code>quirks</code>", and <dfn export id=concept-document-limited-quirks>limited-quirks mode</dfn> if its <a for=Document>mode</a> is "<code>limited-quirks</code>".
+A <a href="#concept-document">document</a> is said to be in <dfn export id=concept-document-no-quirks>no-quirks mode</dfn> if its <a for=Document>mode</a> is "<code>no-quirks</code>", <dfn export id=concept-document-quirks>quirks mode</dfn> if its <a for=Document>mode</a> is "<code>quirks</code>", and <dfn export id=concept-document-limited-quirks>limited-quirks mode</dfn> if its <a for=Document>mode</a> is "<code>limited-quirks</code>".
 
-<div class="note no-backref"> <p>The <a for=Document>mode</a> is only ever changed from the default for <a>documents</a> created by the <a>HTML parser</a> based on the presence, absence, or value of the DOCTYPE string, and by a new <a>browsing context</a> (initial "<code>about:blank</code>"). [[!HTML]]
+<div class="note no-backref"> <p>The <a for=Document>mode</a> is only ever changed from the default for <a href="#concept-document">documents</a> created by the <a>HTML parser</a> based on the presence, absence, or value of the DOCTYPE string, and by a new <a>browsing context</a> (initial "<code>about:blank</code>"). [[!HTML]]
 
 <p><a>No-quirks mode</a> was originally known as "standards mode" and <a>limited-quirks mode</a> was once known as "almost standards mode". They have been renamed because their details are now defined by standards. (And because Ian Hickson vetoed their original names on the basis that they are nonsensical.)</div>
 
 <hr>
 
 <dl>
- <dt><code><var>document</var> = new <a>Document</a>()</code>
- <dd><p>Returns a new <a>document</a>.
+ <dt><code><var ignore>document</var> = new {{Document()}}</code>
+ <dd><p>Returns a new <a href="#concept-document">document</a>.
 
- <dt><code><var>document</var> . <a>implementation</a></code>
- <dd><p>Returns <var>document</var>'s <code><a>DOMImplementation</a></code> object.
+ <dt><code><var ignore>document</var> . {{Document/implementation}}</code>
+ <dd><p>Returns <var>document</var>'s <code>{{DOMImplementation}}</code> object.
 
- <dt><code><var>document</var> . <a href="#document-url">URL</a></code>
- <dt><code><var>document</var> . <a>documentURI</a></code>
- <dd><p>Returns <var>document</var>'s <a href="#document-url">URL</a>.
+ <dt><code><var>document</var> . {{Document/URL}}</code>
+ <dt><code><var>document</var> . {{Document/documentURI}}</code>
+ <dd><p>Returns <var>document</var>'s <a href="#concept-document-url">URL</a>.
 
- <dt><code><var>document</var> . <a href="#document-origin">origin</a></code>
+ <dt><code><var>document</var> . {{Document/origin}}</code>
  <dd><p>Returns <var>document</var>'s <a href="#concept-document-origin">origin</a>.
 
- <dt><code><var>document</var> . <a>compatMode</a></code>
+ <dt><code><var>document</var> . {{Document/compatMode}}</code>
  <dd>
   <p>Returns the string "<code>BackCompat</code>" if <var>document</var>'s <a for=Document>mode</a> is "<code>quirks mode</code>", and "<code>CSS1Compat</code>" otherwise.
 
- <dt><code><var>document</var> . <a>characterSet</a></code>
- <dd><p>Returns <var>document</var>'s <a href="#document-encoding">encoding</a>.
+ <dt><code><var>document</var> . {{Document/characterSet}}</code>
+ <dd><p>Returns <var>document</var>'s <a href="#concept-document-encoding">encoding</a>.
 
- <dt><code><var>document</var> . <a>contentType</a></code>
+ <dt><code><var>document</var> . {{Document/contentType}}</code>
  <dd><p>Returns <var>document</var>'s <a>content type</a>.
 </dl>
 
-<p>The <dfn><code>Document()</code></dfn> constructor must return a new <a>document</a> whose <a href="#concept-document-origin">origin</a> is the <a href="#concept-document-origin">origin</a> of the global object's associated <a>document</a>. [[!HTML51]]
+<p>The <dfn constructor for=Document><code>Document()</code></dfn> constructor must return a new <a href="#concept-document">document</a> whose <a href="#concept-document-origin">origin</a> is the <a href="#concept-document-origin">origin</a> of the global object's associated <a href="#concept-document">document</a>. [[!HTML51]]
 
-<p class="note">Note: Unlike <code><a>createDocument()</a></code>, this constructor does not return an <code><a>XMLDocument</a></code> object, but a <a href="#concept-document">document</a> (<code><a href="#dom-document">Document</a></code> object).
+<p class="note">Note: Unlike <code>{{DOMImplementation/createDocument()}}</code>, this constructor does not return an <code>{{XMLDocument}}</code> object, but a <a href="#concept-document">document</a> (<code>{{Document}}</code> object).
 
-<p>The <dfn><code>implementation</code></dfn> attribute must return the <code><a>DOMImplementation</a></code> object that is associated with the <a>document</a>.
+<p>The <dfn attribute for=Document><code>implementation</code></dfn> attribute's getter must return the <code>{{DOMImplementation}}</code> object that is associated with the <a href="#concept-document">document</a>.
 
-<p>The <dfn id="document-url"><code>URL</code></dfn> and <dfn><code>documentURI</code></dfn> attributes must return the <a href="#document-url">URL</a>.
+<p>The <dfn attribute for=Document id="document-url"><code>URL</code></dfn>'s getter and <dfn attribute for=Document><code>documentURI</code></dfn> attribute's getter must return the <a href="#concept-document-url">URL</a>.
 
-<p>The <dfn id="document-origin" for="document"><code>origin</code></dfn> attribute must return the <a spec=HTML51>Unicode serialization</a> of <a>context object</a>'s <a href="#concept-document-origin">origin</a>.
+<p>The <dfn attribute for=Document id="document-origin"><code>origin</code></dfn> attribute's getter must return the <a spec=HTML51>Unicode serialization</a> of <a>context object</a>'s <a href="#concept-document-origin">origin</a>.
 
-<p>The <dfn><code>compatMode</code></dfn> attribute's getter must return "<code>BackCompat</code>" if the <a>context object</a>'s <a for=Document>mode</a> is "<code>quirks</code>", and "<code>CSS1Compat</code>" otherwise.
+<p>The <dfn attribute for=Document><code>compatMode</code></dfn> attribute's getter must return "<code>BackCompat</code>" if the <a>context object</a>'s <a for=Document>mode</a> is "<code>quirks</code>", and "<code>CSS1Compat</code>" otherwise.
 
-<p>The <dfn><code>characterSet</code></dfn> attribute's getter, <dfn><code>charSet</code></dfn> attribute's getter, and <dfn><code>inputEncoding</code></dfn> attribute's getter, must return <a>context object</a>'s <a href="#document-encoding">encoding</a>'s <a href="https://www.w3.org/TR/encoding/#name">name</a>.
+<p>The <dfn attribute for=Document><code>characterSet</code></dfn> attribute's getter, <dfn><code>charSet</code></dfn> attribute's getter, and <dfn><code>inputEncoding</code></dfn> attribute's getter, must return <a>context object</a>'s <a href="#concept-document-encoding">encoding</a>'s <a href="https://www.w3.org/TR/encoding/#name">name</a>.
 
-<p>The <dfn><code>contentType</code></dfn> attribute must return the <a>content type</a>.
+<p>The <dfn attribute for=Document><code>contentType</code></dfn> attribute's getter must return the <a>content type</a>.
 
 <hr>
 
 <dl>
- <dt><var>document</var> . <code><a href="#document-doctype">doctype</a></code>
+ <dt><var>document</var> . {{Document/doctype}}
  <dd><p>Returns the <a href="#concept-doctype">doctype</a> or null if there is none.
 
- <dt><var>document</var> . <code><a>documentElement</a></code>
+ <dt><var>document</var> . {{Document/documentElement}}
  <dd><p>Returns the <a>document element</a>.
 
- <dt><var>collection</var> = <var>document</var> . <code><a href="#document-getelementsbytagname-func">getElementsByTagName(<var>localName</var>)</a></code>
+ <dt><var ignore>collection</var> = <var>document</var> . <code>{{Document/getElementsByTagName(localName)}}
 
  <dd>
-  <p>If <var>localName</var> is "<code>*</code>" returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a>.
+  <p>If <var>localName</var> is "<code>*</code>" returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a>.
 
-  <p>Otherwise, returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>. (Matches case-insensitively against <a>elements</a> in the <a>HTML namespace</a> within an <a>HTML document</a>.)
+  <p>Otherwise, returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>. (Matches case-insensitively against <a>elements</a> in the <a>HTML namespace</a> within an <a>HTML document</a>.)
 
- <dt><var>collection</var> = <var>document</var> . <code><a href="#document-getelementsbytagnamens-func">getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</a></code>
+ <dt><var ignore>collection</var> = <var>document</var> . {{Document/getElementsByTagNameNS(namespace, localName)}}
 
  <dd>
-  <p>If <var>namespace</var> and <var>localName</var> are "<code>*</code>" returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a>.
+  <p>If <var>namespace</var> and <var>localName</var> are "<code>*</code>" returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a>.
 
-  <p>If only <var>namespace</var> is "<code>*</code>" returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
+  <p>If only <var>namespace</var> is "<code>*</code>" returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-local-name">local name</a> is <var>localName</var>.
 
-  <p>If only <var>localName</var> is "<code>*</code>" returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var>.
+  <p>If only <var>localName</var> is "<code>*</code>" returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var>.
 
-  <p>Otherwise, returns a <code><a>HTMLCollection</a></code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var> and <a href="#element-local-name">local name</a> is <var>localName</var>.
+  <p>Otherwise, returns a <code>{{HTMLCollection}}</code> of all <a>descendant</a> <a>elements</a> whose <a href="#element-namespace">namespace</a> is <var>namespace</var> and <a href="#element-local-name">local name</a> is <var>localName</var>.
 
- <dt><var>collection</var> = <var>document</var> . <code><a href="#document-getelementsbytagname-func">getElementsByClassName(<var>classes</var>)</a></code>
- <dt><var>collection</var> = <var>element</var> . <code><a href="#element-getelementsbytagname-func">getElementsByClassName(<var>classes</var>)</a></code>
+ <dt><var ignore>collection</var> = <var>document</var> . {{Document/getElementsByClassName(classNames)}}
+ <dt><var ignore>collection</var> = <var>element</var> . {{Element/getElementsByClassName(classNames)}}
  <dd>
-  <p>Returns a <code><a>HTMLCollection</a></code> of the <a>elements</a> in the object on which the method was invoked (a <a>document</a> or an <a>element</a>) that have all the classes given by <var>classes</var>.
+  <p>Returns a <code>{{HTMLCollection}}</code> of the <a>elements</a> in the object on which the method was invoked (a <a href="#concept-document">document</a> or an <a href="#concept-element">element</a>) that have all the classes given by <var>classes</var>.
   <p>The <var>classes</var> argument is interpreted as a space-separated list of classes.
 </dl>
 
-<p>The <dfn id="document-doctype" for="document"><code>doctype</code></dfn> attribute must return the <a href="#tree-child">child</a> of the <a>document</a> that is a <a href="#concept-doctype">doctype</a>, and null otherwise.
+<p>The <dfn attribute for=Document id="document-doctype"><code>doctype</code></dfn> attribute's getter must return the <a href="#tree-child">child</a> of the <a href="#concept-document">document</a> that is a <a href="#concept-doctype">doctype</a>, and null otherwise.
 
-<p>The <dfn><code>documentElement</code></dfn> attribute must return the <a>document element</a>.
+<p>The <dfn attribute for=Document><code>documentElement</code></dfn> attribute's getter must return the <a>document element</a>.
 
-<p>The <dfn id="document-getelementsbytagname-func" for="document"><code>getElementsByTagName(<var>localName</var>)</code></dfn> method must return the <a>list of elements with local name <var>localName</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Document><code>getElementsByTagName(<var>localName</var>)</code></dfn> method, when invoked, must return the <a>list of elements with local name <var>localName</var></a> for the <a>context object</a>.
 
 <p class="note">Note: Thus, in an <a>HTML document</a>, <code>document.getElementsByTagName("FOO")</code> will match <code>FOO</code> elements that are not in the <a>HTML namespace</a>, and <code>foo</code> elements that are in the <a>HTML namespace</a>, but not <code>FOO</code> elements that are in the <a>HTML namespace</a>.
 
 
-<p>The <dfn id="document-getelementsbytagnamens-func" for="document"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method must return the <a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Document><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked, must return the <a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for the <a>context object</a>.
 
-<p>The <dfn id="element-getelementsbyclassname-func" for="document"><code>getElementsByClassName(<var>classNames</var>)</code></dfn> method must return the <a>list of elements with class names <var>classNames</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Document><code>getElementsByClassName(<var>classNames</var>)</code></dfn> method, when invoked, must return the <a>list of elements with class names <var>classNames</var></a> for the <a>context object</a>.
 
 <div class="example">
  <p>Given the following XHTML fragment:
@@ -1957,75 +1951,71 @@ A <a>document</a> is said to be in <dfn export id=concept-document-no-quirks>no-
   &lt;p id="p3" class="bbb ccc"/&gt;
 &lt;/div&gt;</pre>
 
- <p>A call to <code>document.getElementById('example').getElementsByClassName('aaa')</code> would return a <code><a>HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.
+ <p>A call to <code>document.getElementById('example').getElementsByClassName('aaa')</code> would return a <code>{{HTMLCollection}}</code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.
 
  <p>A call to <code>getElementsByClassName('ccc bbb')</code> would only return one node, however, namely <code>p3</code>. A call to <code>document.getElementById('example').getElementsByClassName('bbb  ccc ')</code> would return the same thing.
-
- <p>A call to <code>getElementsByClassName('aaa,bbb')</code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.
-</div>
-
-<hr>
+<p>A call to <code>getElementsByClassName('aaa,bbb')</code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.  </div> <hr>
 
 <dl>
- <dt><var>element</var> = <var>document</var> . <code><a>createElement(<var>localName</var>)</a></code>
+ <dt><var ignore>element</var> = <var>document</var> . {{Document/createElement(localName)}}
  <dd>
-  <p>Returns an <a>element</a> in the <a>HTML namespace</a> [see <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=19431'>bug 19431</a>] with <var>localName</var> as <a href="#element-local-name">local name</a>. (In an <a>HTML document</a> <var>localName</var> is lowercased.)
+  <p>Returns an <a href="#concept-element">element</a> in the <a>HTML namespace</a> [see <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=19431'>bug 19431</a>] with <var>localName</var> as <a href="#element-local-name">local name</a>. (In an <a>HTML document</a> <var>localName</var> is lowercased.)
 
-  <p>If <var>localName</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an "<code><a>InvalidCharacterError</a></code>" will be thrown.
+ <dt><var ignore>element</var> = <var>document</var> . {{Document/createElement(localName)}}
 
- <dt><var>element</var> = <var>document</var> . <code><a>createElementNS(<var>namespace</var>, <var>qualifiedName</var>)</a></code>
+ <dt><var ignore>element</var> = <var>document</var> . {{Document/createElementNS(namespace, qualifiedName)}}
 
  <dd>
-  <p>Returns an <a>element</a> with <a href="#element-namespace">namespace</a> <var>namespace</var>. Its <a href="#element-namespace-prefix">namespace prefix</a> will be everything before "<code>:</code>" (U+003E) in <var>qualifiedName</var> or null. Its <a href="#element-local-name">local name</a> will be everything after "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>.
+  <p>Returns an <a href="#concept-element">element</a> with <a href="#element-namespace">namespace</a> <var>namespace</var>. Its <a href="#element-namespace-prefix">namespace prefix</a> will be everything before "<code>:</code>" (U+003E) in <var>qualifiedName</var> or null. Its <a href="#element-local-name">local name</a> will be everything after "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>.
 
-  <p>If <var>localName</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an "<code><a>InvalidCharacterError</a></code>" will be thrown.
+  <p>If <var>localName</var> does not match the <code><a type>Name</a></code> production an "<code><a>InvalidCharacterError</a></code>" will be thrown.
 
   <p>If one of the following conditions is true a "<code><a>NamespaceError</a></code>" will be thrown:
 
   <ul>
-   <li><var>localName</var> does not match the <code><a>QName</a></code> production.
+   <li><var>localName</var> does not match the <code><a type>QName</a></code> production.
    <li><a href="#element-namespace-prefix">Namespace prefix</a> is not null and <var>namespace</var> is the empty string.
    <li><a href="#element-namespace-prefix">Namespace prefix</a> is "<code>xml</code>" and <var>namespace</var> is not the <a>XML namespace</a>.
    <li><var>qualifiedName</var> or <a href="#element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <var>namespace</var> is not the <a>XMLNS namespace</a>.
    <li><var>namespace</var> is the <a>XMLNS namespace</a> and neither <var>qualifiedName</var> nor <a href="#element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>".
   </ul>
 
- <dt><var>documentFragment</var> = <var>document</var> . <code><a>createDocumentFragment()</a></code>
- <dd><p>Returns a {{DocumentFragment}} <a>node</a>.
+ <dt><var ignore>documentFragment</var> = <var>document</var> . {{Document/createDocumentFragment()}}
+ <dd><p>Returns a {{DocumentFragment}} <a href="#concept-node">node</a>.
 
- <dt><var>text</var> = <var>document</var> . <code><a>createTextNode(<var>data</var>)</a></code>
- <dd><p>Returns a {{Text}} <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
+ <dt><var ignore>text</var> = <var>document</var> . {{Document/createTextNode(data)}}
+ <dd><p>Returns a {{Text}} <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
 
- <dt><var>cdataSection</var> = <var>document</var> . <code><a>createCDATASection(<var>data</var>)</a></code>
- <dd><p>Returns a {{CDATASection}} <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
+ <dt><var ignore>cdataSection</var> = <var>document</var> . {{Document/createCDATASection(data)}}
+ <dd><p>Returns a {{CDATASection}} <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
 
- <dt><var>comment</var> = <var>document</var> . <code><a>createComment(<var>data</var>)</a></code>
- <dd><p>Returns a {{Comment}} <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
+ <dt><var ignore>comment</var> = <var>document</var> . {{Document/createComment(data)}}
+ <dd><p>Returns a {{Comment}} <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
 
- <dt><var>processingInstruction</var> = <var>document</var> . <code><a>createProcessingInstruction(<var>target</var>, <var>data</var>)</a></code>
+ <dt><var ignore>processingInstruction</var> = <var>document</var> . {{Document/createProcessingInstruction(target, data)}}
  <dd>
-  <p>Returns a {{ProcessingInstruction}} <a>node</a> whose <a href="#pi-target">target</a> is <var>target</var> and <a href="#cd-data">data</a> is <var>data</var>.
-  <p>If <var>target</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an "<code><a>InvalidCharacterError</a></code>" will be thrown.
+  <p>Returns a {{ProcessingInstruction}} <a href="#concept-node">node</a> whose <a href="#pi-target">target</a> is <var>target</var> and <a href="#cd-data">data</a> is <var>data</var>.
+  <p>If <var>target</var> does not match the <code><a type>Name</a></code> production an "<code><a>InvalidCharacterError</a></code>" will be thrown.
   <p>If <var>data</var> contains "<code>?&gt;</code>" an "<code><a>InvalidCharacterError</a></code>" will be thrown.
 </dl>
 
-<p>The <dfn>element interface</dfn> for any <var>name</var> and <var>namespace</var> is <code><a>Element</a></code>, unless stated otherwise.
+<p>The <dfn>element interface</dfn> for any <var>name</var> and <var>namespace</var> is <code>{{Element}}</code>, unless stated otherwise.
 
 <p class="note">Note: The HTML Standard will e.g. define that for <code>html</code> and the <a>HTML namespace</a>, the <code>HTMLHtmlElement</code> interface is used. [[!HTML5]
 
-<p>The <dfn><code>createElement(<var>localName</var>)</code></dfn> method must run the these steps:
+<p>The <dfn method for=Document><code>createElement(<var>localName</var>)</code></dfn> method, when invoked, must run the these steps:
 
 <ol>
- <li><p>If <var>localName</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
+ <li><p>If <var>localName</var> does not match the <code><a type>Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
 
  <li><p>If the <a>context object</a> is an <a>HTML document</a>, let <var>localName</var> be <a>converted to ASCII lowercase</a>.
 
  <li><p>Let <var>interface</var> be the <a>element interface</a> for <var>localName</var> and the <a>HTML namespace</a>.
 
- <li><p>Return a new <a>element</a> that implements <var>interface</var>, with no attributes, <a href="#element-namespace">namespace</a> set to the <a>HTML namespace</a> [see <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=19431'>bug 19431</a>], <a href="#element-local-name">local name</a> set to <var>localName</var>, and <a>node document</a> set to the <a>context object</a>.
+ <li><p>Return a new <a href="#concept-element">element</a> that implements <var>interface</var>, with no attributes, <a href="#element-namespace">namespace</a> set to the <a>HTML namespace</a> [see <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=19431'>bug 19431</a>], <a href="#element-local-name">local name</a> set to <var>localName</var>, and <a>node document</a> set to the <a>context object</a>.
 </ol>
 
-<p>The <dfn><code>createElementNS(<var>namespace</var>, <var>qualifiedName</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>createElementNS(<var>namespace</var>, <var>qualifiedName</var>)</code></dfn> method, when invoked, must run these steps:
 <ol>
  <li><p>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of
  passing <var>namespace</var> and <var>qualifiedName</var> to <a>validate and extract</a>. Rethrow
@@ -2043,11 +2033,11 @@ A <a>document</a> is said to be in <dfn export id=concept-document-no-quirks>no-
  <a href="#node-document" title="node-document">node document</a> set to the <a href="#context-object">context object</a>.
 </ol>
 
-<p>The <dfn><code>createDocumentFragment()</code></dfn> method must return a new <code><a>DocumentFragment</a></code> <a>node</a> with its <a>node document</a> set to the <a href="#context-object">context object</a>.
+<p>The <dfn method for=Document><code>createDocumentFragment()</code></dfn> method, when invoked, must return a new <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a> with its <a>node document</a> set to the <a href="#context-object">context object</a>.
 
-<p>The <dfn><code>createTextNode(<var>data</var>)</code></dfn> method must return a new <code><a>Text</a></code> <a>node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and <a>node document</a> set to the <a>context object</a>.
+<p>The <dfn method for=Document><code>createTextNode(<var>data</var>)</code></dfn> method, when invoked, must return a new <code>{{Text}}</code> <a href="#concept-node">node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and <a>node document</a> set to the <a>context object</a>.
 
-<p class="note">Note: No check is performed that <var>data</var> consists of characters that match the <code><a href="http://www.w3.org/TR/xml/#NT-Char">Char</a></code> production.
+<p class="note">Note: No check is performed that <var>data</var> consists of characters that match the <code><a type>Char</a></code> production.
 
 <p>The <dfn method for=Document><code>createCDATASection(<var>data</var>)</code></dfn> method, when
 invoked, must run these steps:
@@ -2059,47 +2049,47 @@ invoked, must run these steps:
  <li><p>If <var>data</var> contains the string "<code>]]></code>", then <a>throw</a> an
  {{InvalidCharacterError}}.
 
- <li><p>Return a new {{CDATASection}} <a>node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and
+ <li><p>Return a new {{CDATASection}} <a href="#concept-node">node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and
  <a href="#node-document">node document</a> set to the <a>context object</a>.
 </ol>
 
-<p>The <dfn><code>createComment(<var>data</var>)</code></dfn> method must return a new <code><a>Comment</a></code> <a>node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and <a>node document</a> set to the <a>context object</a>.
-<p class="note">Note: No check is performed that <var>data</var> consists of characters that match the <code><a href="http://www.w3.org/TR/xml/#NT-Char">Char</a></code> production or that it contains two adjacent hyphens or ends with a hyphen.
+<p>The <dfn method for=Document><code>createComment(<var>data</var>)</code></dfn> method, when invoked, must return a new <code>{{Comment}}</code> <a href="#concept-node">node</a> with its <a href="#cd-data">data</a> set to <var>data</var> and <a>node document</a> set to the <a>context object</a>.
+<p class="note">Note: No check is performed that <var>data</var> consists of characters that match the <code><a type>Char</a></code> production or that it contains two adjacent hyphens or ends with a hyphen.
 
-<p>The <dfn><code>createProcessingInstruction(<var>target</var>, <var>data</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>createProcessingInstruction(<var>target</var>, <var>data</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>target</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>". <!-- DOM3 does not check for "xml" -->
+ <li><p>If <var>target</var> does not match the <code><a type>Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>". <!-- DOM3 does not check for "xml" -->
 
  <li><p>If <var>data</var> contains the string "<code>?&gt;</code>", <a>throw</a> an "<code><a>InvalidCharacterError</a></code>". <!-- Gecko does this. -->
 
- <li><p>Return a new <code><a>ProcessingInstruction</a></code> <a>node</a>, with <a href="#pi-target">target</a> set to <var>target</var>, <a href="#cd-data">data</a> set to <var>data</var>, and <a>node document</a> set to the <a>context object</a>.
+ <li><p>Return a new <code>{{ProcessingInstruction}}</code> <a href="#concept-node">node</a>, with <a href="#pi-target">target</a> set to <var>target</var>, <a href="#cd-data">data</a> set to <var>data</var>, and <a>node document</a> set to the <a>context object</a>.
 </ol>
 
-<p class="note">Note: No check is performed that <var>target</var> contains "<code>xml</code>" or "<code>:</code>", or that <var>data</var> contains characters that match the <code><a href="http://www.w3.org/TR/xml/#NT-Char">Char</a></code> production.
+<p class="note">Note: No check is performed that <var>target</var> contains "<code>xml</code>" or "<code>:</code>", or that <var>data</var> contains characters that match the <code><a type>Char</a></code> production.
 
 <hr>
 
 <dl>
- <dt><var>clone</var> = <var>document</var> . <code><a>importNode(<var>node</var> [, <var>deep</var> = false])</a></code>
+ <dt><var ignore>clone</var> = <var>document</var> . <a method for=Document lt=importNode()>importNode(<var>node</var> [, <var>deep</var> = false])</a>
  <dd>
  <dd>
   <p>Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>'s <a>descendants</a>.
 
-  <p>If <var>node</var> is a <a>document</a> throws a "<code><a>NotSupportedError</a></code>".
+  <p>If <var>node</var> is a <a href="#concept-document">document</a> throws a "<code><a>NotSupportedError</a></code>".
 
- <dt><var>node</var> = <var>document</var> . <code><a>adoptNode(<var>node</var>)</a></code>
+ <dt><var ignore>node</var> = <var>document</var> . <code><a>adoptNode(<var>node</var>)</a></code>
 
  <dd>
-  <p>Moves <var>node</var> from another <a>document</a> and returns it.
+  <p>Moves <var>node</var> from another <a href="#concept-document">document</a> and returns it.
 
-  <p>If <var>node</var> is a <a>document</a> throws a "<code><a>NotSupportedError</a></code>".
+  <p>If <var>node</var> is a <a href="#concept-document">document</a> throws a "<code><a>NotSupportedError</a></code>".
 </dl>
 
-<p>The <dfn><code>importNode(<var>node</var>, <var>deep</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>importNode(<var>node</var>, <var>deep</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>node</var> is a <a>document</a>, <a>throw</a> a "<code><a>NotSupportedError</a></code>".
+ <li><p>If <var>node</var> is a <a href="#concept-document">document</a>, <a>throw</a> a "<code><a>NotSupportedError</a></code>".
 
  <li><p>Return a <a href="#node-clone">clone</a> of <var>node</var>, with <a>context object</a> and the <i>clone children flag</i> set if <var>deep</var> is true.
 </ol>
@@ -2125,7 +2115,7 @@ invoked, must run these steps:
 
      <li><p>If <var>inclusiveDescendant</var> is an <a href="#concept-element">element</a>, then set the
      <a>node document</a> of each <a href="#concept-attribute">attribute</a> in <var>inclusiveDescendant</var>'s
-     <a>attribute list</a> to <var>document</var>.
+     <a for=Element>attribute list</a> to <var>document</var>.
     </ol>
 
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
@@ -2134,10 +2124,10 @@ invoked, must run these steps:
   </ol>
 </ol>
 
-<p>The <dfn><code>adoptNode(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>adoptNode(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>node</var> is a <a>document</a>, <a>throw</a> a "<code><a>NotSupportedError</a></code>".
+ <li><p>If <var>node</var> is a <a href="#concept-document">document</a>, <a>throw</a> a "<code><a>NotSupportedError</a></code>".
 
  <li><p><a>Adopt</a> <var>node</var> into the <a>context object</a>.
 
@@ -2150,32 +2140,31 @@ The <dfn method for=Document><code>createAttribute(<var>localName</var>)</code><
 invoked, must run these steps:
 
 <ol>
- <li><p>If <var>localName</var> does not match the <code><a href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production in XML,
+ <li><p>If <var>localName</var> does not match the <code><a type>Name</a></code> production in XML,
  then <a>throw</a> an {{InvalidCharacterError}}.
 
  <li>If the <a>context object</a> is an <a>HTML document</a>, then set <var>localName</var> to
  <var>localName</var> in <a>ASCII lowercase</a>.
 
- <li>Return a new <a>attribute</a> whose <a href="#attr-local-name">local name</a> is <var>localName</var> and
+ <li>Return a new <a href="#concept-attribute">attribute</a> whose <a href="#attribute-local-name">local name</a> is <var>localName</var> and
  <a>node document</a> is <a>context object</a>.
 </ol>
 
-The
-<dfn method for=Document><code>createAttributeNS(<var>namespace</var>, <var>qualifiedName</var>)</code></dfn>
+The <dfn method for=Document><code>createAttributeNS(<var>namespace</var>, <var>qualifiedName</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of
  passing <var>namespace</var> and <var>qualifiedName</var> to <a>validate and extract</a>.
 
- <li><p>Return a new <a>attribute</a> whose <a href="#attr-namespace">namespace</a> is <var>namespace</var>,
+ <li><p>Return a new <a href="#concept-attribute">attribute</a> whose <a href="#attribute-namespace">namespace</a> is <var>namespace</var>,
  <a href="#attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a href="#attribute-local-name">local name</a> is
  <var>localName</var>, and <a>node document</a> is <a>context object</a>.
 </ol>
 
 <hr>
 
-<p>The <dfn><code>createEvent(<var>interface</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>createEvent(<var>interface</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>constructor</var> be null.
@@ -2227,36 +2216,36 @@ method, when invoked, must run these steps:
 
 <hr>
 
-<p>The <dfn><code>createRange()</code></dfn> method must return a new <a>range</a> with (<a>context object</a>, 0) as its <a>start</a> and <a>end</a>.
+<p>The <dfn method for=Document><code>createRange()</code></dfn> method, when invoked, must return a new <a href="#concept-range">range</a> with (<a>context object</a>, 0) as its <a>start</a> and <a>end</a>.
 
 <p class="note">Note: The <code><a>Range()</a></code> constructor can be used instead.
 
 <hr>
 
-<p>The <dfn><code>createNodeIterator(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>createNodeIterator(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>Create a <code><a>NodeIterator</a></code> object.
- <li><p>Set <a href="#traversal-root">root</a> and initialize the <code><a>referenceNode</a></code> attribute to the <var>root</var> argument.
- <li><p>Initialize the <code><a>pointerBeforeReferenceNode</a></code> attribute to true.
+ <li><p>Create a <code>{{NodeIterator}}</code> object.
+ <li><p>Set <a href="#traversal-root">root</a> and initialize the <code>{{NodeIterator/referenceNode}}</code> attribute to the <var>root</var> argument.
+ <li><p>Initialize the <code>{{NodeIterator/pointerBeforeReferenceNode}}</code> attribute to true.
  <li><p>Set <a href="#traversal-whattoshow">whatToShow</a> to the <var>whatToShow</var> argument.
  <li><p>Set <a href="#traversal-filter" title="traversal-filter">filter</a> to <var>filter</var>.
- <li><p>Return the newly created <code><a>NodeIterator</a></code> object.
+ <li><p>Return the newly created <code>{{NodeIterator}}</code> object.
 </ol>
 
-<p>The <dfn><code>createTreeWalker(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Document><code>createTreeWalker(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>Create a <code><a>TreeWalker</a></code> object.
- <li><p>Set <a href="#traversal-root" title="traversal-root">root</a> and initialize the <code><a>currentNode</a></code> attribute to the <var>root</var> argument.
+ <li><p>Create a <code>{{TreeWalker}}</code> object.
+ <li><p>Set <a href="#traversal-root" title="traversal-root">root</a> and initialize the <code>{{TreeWalker/currentNode}}</code> attribute to the <var>root</var> argument.
  <li><p>Set <a href="#traversal-whattoshow">whatToShow</a> to the <var>whatToShow</var> argument.
  <li><p>Set <a href="#traversal-filter" title="traversal-filter">filter</a> to <var>filter</var>.
- <li><p>Return the newly created <code><a>TreeWalker</a></code> object.
+ <li><p>Return the newly created <code>{{TreeWalker}}</code> object.
 </ol>
 
-<h4 id="interface-domimplementation">Interface <code><a>DOMImplementation</a></code></h4>
+<h4 id="interface-domimplementation">Interface <code>{{DOMImplementation}}</code></h4>
 
-<p>User agents must create a <code><a>DOMImplementation</a></code> object whenever a <a>document</a> is created and associate it with that <a>document</a>.
+<p>User agents must create a <code>{{DOMImplementation}}</code> object whenever a <a href="#concept-document">document</a> is created and associate it with that <a href="#concept-document">document</a>.
 
 <pre class='idl'>
 [Exposed=Window]
@@ -2270,48 +2259,48 @@ interface DOMImplementation {
 </pre>
 
 <dl>
- <dt><code><var>doctype</var> = <var>document</var> . <a>implementation</a> . <a>createDocumentType</a>(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)</code>
+ <dt><code><var ignore>doctype</var> = <var>document</var> . {{Document/implementation}} . {{DOMImplementation/createDocumentType(qualifiedName, publicId, systemId)}}
 
  <dd>
-  <p>Returns a <a>doctype</a>, with the given <var>qualifiedName</var>, <var>publicId</var>, and <var>systemId</var>. If <var>qualifiedName</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, an "<code><a>InvalidCharacterError</a></code>" is thrown, and if it does not match the <code><a>QName</a></code> production, a "<code><a>NamespaceError</a></code>" is thrown.
+  <p>Returns a <a href="#concept-doctype">doctype</a>, with the given <var>qualifiedName</var>, <var>publicId</var>, and <var>systemId</var>. If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production, an "<code><a>InvalidCharacterError</a></code>" is thrown, and if it does not match the <code><a type>QName</a></code> production, a "<code><a>NamespaceError</a></code>" is thrown.
 
- <dt><code><var>doc</var> = <var>document</var> . <a>implementation</a> . <a>createDocument</a>(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</code>
-
- <dd>
-  <p>Returns an <code><a>XMLDocument</a></code> [see <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22960">bug 22960</a>], with a <a>document element</a> whose <a href="#element-local-name">local name</a> is <var>qualifiedName</var> and whose <a href="#element-namespace">namespace</a> is <var>namespace</var> (unless <var>qualifiedName</var> is the empty string), and with <var>doctype</var>, if it is given, as its <a href="#concept-doctype">doctype</a>.
-
-  <p>This method throws the same exceptions as the <code><a>createElementNS</a></code> method, when invoked with the same arguments.
-
- <dt><code><var>doc</var> = <var>document</var> . <a>implementation</a> . <a>createHTMLDocument</a>([<var>title</var>])</code>
+ <dt><code><var ignore>doc</var> = <var>document</var> . {{Document/implementation}} . <a method for=DOMImplementation lt=createDocument()>createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code>
 
  <dd>
-  <p>Returns a <a>document</a>, with a basic <a>tree</a> already constructed including a <code>title</code> element, unless the <var>title</var> argument is omitted.
+  <p>Returns an <code>{{XMLDocument}}</code> [see <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22960">bug 22960</a>], with a <a>document element</a> whose <a href="#element-local-name">local name</a> is <var>qualifiedName</var> and whose <a href="#element-namespace">namespace</a> is <var>namespace</var> (unless <var>qualifiedName</var> is the empty string), and with <var>doctype</var>, if it is given, as its <a href="#concept-doctype">doctype</a>.
+
+  <p>This method throws the same exceptions as the <code>{{Document/createElementNS()}}</code> method, when invoked with the same arguments.
+
+ <dt><code><var ignore>doc</var> = <var>document</var> . {{Document/implementation}} . {{DOMImplementation/createHTMLDocument(title)}}</code>
+
+ <dd>
+  <p>Returns a <a href="#concept-document">document</a>, with a basic <a>tree</a> already constructed including a <code>title</code> element, unless the <var>title</var> argument is omitted.
 </dl>
 
 <div>
 
-<p>The <dfn><code>createDocumentType(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=DOMImplementation><code>createDocumentType(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>qualifiedName</var> does not match the <code><a>Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
- <li><p>If <var>qualifiedName</var> does not match the <code><a>QName</a></code> production, <a>throw</a> a "<code><a>NamespaceError</a></code>".
- <li><p>Return a new <a href="#concept-doctype">doctype</a>, with <var>qualifiedName</var> as its <a href="#doctype-name">name</a>, <var>publicId</var> as its <a>public ID</a>, and <var>systemId</var> as its <a>system ID</a>, and with its <a>node document</a> set to the associated <a>document</a> of the <a>context object</a>.
+ <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
+ <li><p>If <var>qualifiedName</var> does not match the <code><a type>QName</a></code> production, <a>throw</a> a "<code><a>NamespaceError</a></code>".
+ <li><p>Return a new <a href="#concept-doctype">doctype</a>, with <var>qualifiedName</var> as its <a href="#doctype-name">name</a>, <var>publicId</var> as its <a>public ID</a>, and <var>systemId</var> as its <a>system ID</a>, and with its <a>node document</a> set to the associated <a href="#concept-document">document</a> of the <a>context object</a>.
 </ol>
 <p class="note">Note: No check is performed that <var>publicId</var> matches the <code>PublicChar</code> production or that <var>systemId</var> does not contain both a '<code>"</code>' and "<code>'</code>".
 
-<p>The <dfn><code>createDocument(<var>namespace</var>, <var>qualifiedName</var>, <var>doctype</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=DOMImplementation><code>createDocument(<var>namespace</var>, <var>qualifiedName</var>, <var>doctype</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li>
-  <p>Let <var>document</var> be a new <code><a href="#xmldocument">XMLDocument</a></code> [see <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22960">bug 22960</a>].
+  <p>Let <var>document</var> be a new <code>{{XMLDocument}}</code> [see <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22960">bug 22960</a>].
 
  <li><p>Let <var>element</var> be null.
 
- <li><p>If <var>qualifiedName</var> is not the empty string, set <var>element</var> to the result of invoking the <code><a>createElementNS()</a></code> method with the arguments <var>namespace</var> and <var>qualifiedName</var> on <var>document</var>. Rethrow any exceptions.
+ <li><p>If <var>qualifiedName</var> is not the empty string, set <var>element</var> to the result of invoking the <code>{{Document/createElementNS()}}</code> method with the arguments <var>namespace</var> and <var>qualifiedName</var> on <var>document</var>. Rethrow any exceptions.
 
- <li><p>If <var>doctype</var> is not null, <a>append</a> <var>doctype</var> to <var>document</var>.
+ <li><p>If <var>doctype</var> is not null, <a href="#node-append">append</a> <var>doctype</var> to <var>document</var>.
 
- <li><p>If <var>element</var> is not null, <a>append</a> <var>element</var> to <var>document</var>.
+ <li><p>If <var>element</var> is not null, <a href="#node-append">append</a> <var>element</var> to <var>document</var>.
 
  <li><p><var>document</var>'s <a href="#concept-document-origin">origin</a> is <a>context object</a>'s associated <a href="#concept-document">document</a>'s <a href="#concept-document-origin">origin</a>.
 
@@ -2325,49 +2314,49 @@ interface DOMImplementation {
       <dt><a>SVG namespace</a>
       <dd><code>image/svg+xml</code>
 
-      <dt><a>Any other namespace</a>
+      <dt>Any other namespace
       <dd><code>application/xml</code>
     </dl>
 
  <li><p>Return <var>document</var>.
 </ol>
 
-<p>The <dfn><code>createHTMLDocument(<var>title</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=DOMImplementation><code>createHTMLDocument(<var>title</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>doc</var> be a new <a>document</a> that is an <a>HTML document</a>.
+ <li><p>Let <var>doc</var> be a new <a href="#concept-document">document</a> that is an <a>HTML document</a>.
 
  <li><p>Set <var>doc</var>'s <a>content type</a> to "<code>text/html</code>".
 
- <li><p>Create a <a>doctype</a>, with "<code>html</code>" as its <a href="#doctype-name">name</a> and with its <a>node document</a> set to <var>doc</var>. <a>Append</a> the newly created node to <var>doc</var>.
+ <li><p>Create a <a href="#concept-doctype">doctype</a>, with "<code>html</code>" as its <a href="#doctype-name">name</a> and with its <a>node document</a> set to <var>doc</var>. <a href="#node-append">append</a> the newly created node to <var>doc</var>.
 
- <li><p>Create an <code>html</code> element in the <a>HTML namespace</a>, and <a>append</a> it to <var>doc</var>.
+ <li><p>Create an <code>html</code> element in the <a>HTML namespace</a>, and <a href="#node-append">append</a> it to <var>doc</var>.
 
- <li><p>Create a <code>head</code> element in the <a>HTML namespace</a>, and  <a>append</a> it to the <code>html</code> element created in the previous step.
+ <li><p>Create a <code>head</code> element in the <a>HTML namespace</a>, and  <a href="#node-append">append</a> it to the <code>html</code> element created in the previous step.
 
  <li>
   <p>If the <var>title</var> argument is not omitted:
 
   <ol>
-   <li><p>Create a <code>title</code> element in the <a>HTML namespace</a>, and <a>append</a> it to the <code>head</code> element created in the previous step.
+   <li><p>Create a <code>title</code> element in the <a>HTML namespace</a>, and <a href="#node-append">append</a> it to the <code>head</code> element created in the previous step.
 
-   <li><p>Create a <code><a>Text</a></code> <a>node</a>, set its <a href="#cd-data">data</a> to <var>title</var> (which could be the empty string), and <a>append</a> it to the <code>title</code> element created in the previous step.
+   <li><p>Create a <code>{{Text}}</code> <a href="#concept-node">node</a>, set its <a href="#cd-data">data</a> to <var>title</var> (which could be the empty string), and <a href="#node-append">append</a> it to the <code>title</code> element created in the previous step.
   </ol>
 
- <li><p>Create a <code>body</code> element in the <a>HTML namespace</a>, and <a>append</a> it to the <code>html</code> element created in the earlier step.
+ <li><p>Create a <code>body</code> element in the <a>HTML namespace</a>, and <a href="#node-append">append</a> it to the <code>html</code> element created in the earlier step.
 
  <li><p><var>document</var>'s <a href="#concept-document-origin">origin</a> is <a>context object</a>'s associated <a href="#concept-document">document</a>'s <a href="#concept-document-origin">origin</a>.
 
  <li><p>Return <var>doc</var>.
 </ol>
 
-<p>The <dfn><code>hasFeature()</code></dfn> method must return true.
+<p>The <dfn method for=DOMImplementation><code>hasFeature()</code></dfn> method, when invoked, must return true.
 
-<p class="note">Note: <code><a>hasFeature()</a></code> originally would report whether the user agent claimed to support a given DOM feature, but experience proved it was not nearly as reliable or granular as simply checking whether the desired objects, attributes, or methods existed. As such, it should no longer be used, but continues to exist (and simply returns true) so that old pages don't stop working.
+<p class="note">Note: <code><a for=DOMImplementation>hasFeature()</a></code> originally would report whether the user agent claimed to support a given DOM feature, but experience proved it was not nearly as reliable or granular as simply checking whether the desired objects, attributes, or methods existed. As such, it should no longer be used, but continues to exist (and simply returns true) so that old pages don't stop working.
 
 </div>
 
-<h3 id="nodes-interface-documentfragment">Interface <code><a>DocumentFragment</a></code></h3>
+<h3 id="nodes-interface-documentfragment">Interface <code>{{DocumentFragment}}</code></h3>
 
 <pre class='idl'>
 [Constructor,
@@ -2376,20 +2365,20 @@ interface DocumentFragment : Node {
 };
 </pre>
 
-<p>A <code><a>DocumentFragment</a></code> <a>node</a> can have an associated <a>element</a> named <dfn>host</dfn>.
+<p>A <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a> can have an associated <a href="#concept-element">element</a> named <dfn>host</dfn>.
 
 <p>An object <var>A</var> is a <dfn>host-including inclusive ancestor</dfn> of an object <var>B</var>, if either <var>A</var> is an <a>inclusive ancestor</a> of <var>B</var>, or if <var>B</var>'s <a href="#tree-root">root</a> has an associated <a>host</a> and <var>A</var> is a <a>host-including inclusive ancestor</a> of <var>B</var>'s <a href="#tree-root">root</a>'s <a>host</a>.
 
-<p class="note">Note: The <code><a>DocumentFragment</a></code> <a>node</a>'s <a>host</a> concept is useful for HTML's <a>template</a> element and impacts the <a>pre-insert</a> and <a href="#node-replace">replace</a> algorithms.
+<p class="note">Note: The <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>'s <a>host</a> concept is useful for HTML's <a>template</a> element and impacts the <a>pre-insert</a> and <a href="#node-replace">replace</a> algorithms.
 
 <dl>
- <dt><code><var>tree</var> = new <a>DocumentFragment</a>()</code>
- <dd><p>Returns a new <code><a>DocumentFragment</a></code> <a>node</a>.
+ <dt><code><var ignore>tree</var> = new {{DocumentFragment}}()</code>
+ <dd><p>Returns a new <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>.
 </dl>
 
-<p>The <dfn><code>DocumentFragment()</code></dfn> constructor must return a new <code><a>DocumentFragment</a></code> <a>node</a> whose <a>node document</a> is the global object's associated <a>document</a>.
+<p>The <dfn constructor for=DocumentFragment><code>DocumentFragment()</code></dfn> constructor must return a new <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a> whose <a>node document</a> is the global object's associated <a href="#concept-document">document</a>.
 
-<h3 id="nodes-interface-documenttype">Interface <code><a>DocumentType</a></code></h3>
+<h3 id="nodes-interface-documenttype">Interface <code>{{DocumentType}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -2400,19 +2389,19 @@ interface DocumentType : Node {
 };
 </pre>
 
-<p><code><a>DocumentType</a></code> <a>nodes</a> are simply known as <dfn id="concept-doctype" for="concept">doctypes</dfn>.
+<p><code>{{DocumentType}}</code> <a>nodes</a> are simply known as <dfn id="concept-doctype" for="concept">doctypes</dfn>.
 
 <p><a href="#concept-doctype">Doctypes</a> have an associated <dfn id="doctype-name">name</dfn>, <dfn>public ID</dfn>, and <dfn>system ID</dfn>.
 
 <p>When a <a href="#concept-doctype">doctype</a> is created, its <a href="#doctype-name">name</a> is always given. Unless explicitly given when a <a href="#concept-doctype">doctype</a> is created, its <a>public ID</a> and <a>system ID</a> are the empty string.
 
-<p>The <dfn id="documenttype-name" for="documenttype"><code>name</code></dfn> attribute must return the <a href="#doctype-name">name</a>.
+<p>The <dfn attribute for=DocumentType id="documenttype-name"><code>name</code></dfn> attribute's getter must return the <a href="#doctype-name">name</a>.
 
-<p>The <dfn><code>publicId</code></dfn> attribute must return the <a>public ID</a>.
+<p>The <dfn attribute for=DocumentType><code>publicId</code></dfn> attribute's getter must return the <a>public ID</a>.
 
-<p>The <dfn><code>systemId</code></dfn> attribute must return the <a>system ID</a>.
+<p>The <dfn attribute for=DocumentType><code>systemId</code></dfn> attribute's getter must return the <a>system ID</a>.
 
-<h3 id="nodes-interface-element">Interface <code><a href="#dom-element">Element</a></code></h3>
+<h3 id="nodes-interface-element">Interface <code>{{Element}}</code></h3>
 <pre class='idl'>
 [Exposed=Window]
 interface Element : Node {
@@ -2455,38 +2444,35 @@ interface Element : Node {
 };
 </pre>
 
-<p><code><dfn id="dom-element" for="dom">Element</dfn></code> <a>nodes</a> are simply known as <dfn id="concept-element" for="concept" lt="element|elements">elements</dfn>.</p>
+<p><code>{{Element}}</code> <a>nodes</a> are simply known as <dfn id="concept-element" lt="element|elements">elements</dfn>.</p>
 
 <p><a href="#concept-element">Elements</a> have an associated <dfn id="element-namespace" for="element">namespace</dfn>, <dfn id="element-namespace-prefix" for="element">namespace prefix</dfn>, and <dfn id="element-local-name" for="element">local name</dfn>. When an <a href="#concept-element">element</a> is created, its <a href="#element-local-name">local name</a> is always given. Unless explicitly given when an <a href="#concept-element">element</a> is created, its <a href="#element-namespace">namespace</a> and <a href="#element-namespace-prefix">namespace prefix</a> are null.
 
-<p>An <a href="#concept-element">element</a>'s
-<a>qualified name</a> is its
-<a href="#element-local-name">local name</a> if its <a href="#element-namespace-prefix">namespace prefix</a> is null, or its
-<a href="#element-namespace-prefix">namespace prefix</a>, followed by "<code>:</code>", followed by its
-<a href="#element-local-name">local name</a>.
+<p>An <a href="#concept-element">element</a>'s <a>qualified name</a> is its <a href="#element-local-name">local name</a> if its <a href="#element-namespace-prefix">namespace prefix</a> is null, or its
+<a href="#element-namespace-prefix">namespace prefix</a>, followed by "<code>:</code>", followed by its <a href="#element-local-name">local name</a>.
 
-<p><a href="#concept-element">Elements</a> also have an ordered <dfn>attribute list</dfn>. Unless explicitly given when an <a href="#concept-element">element</a> is created, its <a>attribute list</a> is empty. An <a href="#concept-element">element</a> <dfn>has</dfn> an <a href="#concept-attribute">attribute</a> <var>A</var> if <var>A</var> is in its <a>attribute list</a>.
+<p><a href="#concept-element">Elements</a> also have an <dfn export id="concept-element-attribute-list" for=Element>attribute list</dfn>, which is a list exposed through a {{NamedNodeMap}}. Unless explicitly given when an <a href="#concept-element">element</a> is created, its <a for=Element>attribute list</a> is empty. An <a href="#concept-element">element</a> <dfn>has</dfn> an <a href="#concept-attribute">attribute</a> <var>A</var> if <var>A</var> is in its <a
+for=Element>attribute list</a>.
 
 This and <a lt="other applicable specifications">other specifications</a> may define
 <dfn>attribute change steps</dfn> for <a href="#concept-element">elements</a>. The algorithm is passed <var>element</var>, <var>localName</var>,
 <var>oldValue</var>, <var>value</var>, and <var>namespace</var>.
 
 To <dfn export id=concept-element-attributes-replace lt="replace an attribute">replace</dfn> an
-<a>attribute</a> <var>oldAttr</var> by an <a>attribute</a> <var>newAttr</var>
+<a href="#concept-attribute">attribute</a> <var>oldAttr</var> by an <a href="#concept-attribute">attribute</a> <var>newAttr</var>
 in an <a href="#concept-element">element</a> <var>element</var>, run these steps:
 
 <ol>
  <li><p><a>Queue a mutation record</a> of "<code>attributes</code>" for <var>element</var>
- with name <var>oldAttr</var>'s <a href="#attribute-localname">local name</a>,
+ with name <var>oldAttr</var>'s <a href="#attribute-local-name">local name</a>,
  namespace <var>oldAttr</var>'s <a href="#attribute-namespace">namespace</a>,
  and oldValue <var>oldAttr</var>'s <a href="#attribute-value">value</a>.
 
  <li><p>Run the <a>attribute change steps</a> with <var>element</var>, <var>oldAttr</var>'s
- <a href="#attribute-localname">local name</a>, <var>oldAttr</var>'s <a href="#attribute-value">value</a>, <var>newAttr</var>'s
+ <a href="#attribute-local-name">local name</a>, <var>oldAttr</var>'s <a href="#attribute-value">value</a>, <var>newAttr</var>'s
  <a href="#attribute-value">value</a>, and <var>oldAttr</var>'s <a href="#attribute-namespace">namespace</a>.
 
- <li><p>Replace <var>oldAttr</var> by <var>newAttr</var> in the <var>element</var>'s
- <a href="#element-attribute-list">attribute list</a>.
+ <li><p>Replace <var>oldAttr</var> by <var>newAttr</var> in the <var>element</var>'s <a for=Element>attribute list</a>.
 
  <li><p>Set <var>oldAttr</var>'s <a href="#concept-element">element</a> to null.
 
@@ -2501,7 +2487,7 @@ To <dfn id="element-attributes-get-by-name">get an attribute by name</dfn> given
  is an <a>HTML document</a>, then set <var>qualifiedName</var> to <var>qualifiedName</var> in
  <a>ASCII lowercase</a>.
 
- <li><p>Return the first <a href="#concept-attribute">attribute</a> in <var>element</var>'s <a>attribute list</a>
+ <li><p>Return the first <a href="#concept-attribute">attribute</a> in <var>element</var>'s <a for=Element>attribute list</a>
  whose <a href="#attribute-qualified-name">qualified name</a> is <var>qualifiedName</var>, and null otherwise.
 </ol>
 
@@ -2513,7 +2499,7 @@ run these steps:
  <li>If <var>namespace</var> is the empty string, set it to null.
 
  <li>Return the <a href="#concept-attribute">attribute</a> in
- <var>element</var>'s <a>attribute list</a>
+ <var>element</var>'s <a for=Element>attribute list</a>
  whose <a href="#attribute-namespace">namespace</a> is
  <var>namespace</var> and
  <a href="#attribute-local-name">local name</a> is
@@ -2601,10 +2587,9 @@ an optional <var>namespace</var>, run these steps:
  <a href="#attribute-local-name">local name</a>, <var>attribute</var>'s <a href="#attribute-value">value</a>, <var>value</var>, and
  <var>attribute</var>'s <a href="#attribute-namespace">namespace</a>.
 
- <li><p>Append the <var>attribute</var> to the <var>element</var>'s <a>attribute list</a>.
+ <li><p>Append the <var>attribute</var> to the <var>element</var>'s <a for=Element>attribute list</a>.
 
- <li>Set <var>attribute</var>'s
- <a for=Attr>element</a> to <var>element</var>.
+ <li>Set <var>attribute</var>'s <a for=Attr>element</a> to <var>element</var>.
 </ol>
 
 <p>To <dfn id="element-attributes-remove" for="element-attributes">remove</dfn> an <a href="#concept-attribute">attribute</a> <var>attribute</var> from an <a href="#concept-element">element</a> <var>element</var>, run these steps:
@@ -2612,9 +2597,13 @@ an optional <var>namespace</var>, run these steps:
 <ol>
  <li><p><a>Queue a mutation record</a> of "<code>attributes</code>" for <var>element</var> with name <var>attribute</var>'s <a href="#attribute-local-name">local name</a>, namespace <var>attribute</var>'s <a href="#attribute-namespace">namespace</a>, and oldValue <var>attribute</var>'s <a href="#attribute-value">value</a>.
 
- <li><p>Remove <var>attribute</var> from the <var>element</var>'s <a>attribute list</a>.
+ <li><p>Run the <a>attribute change steps</a> with <var>element</var>, <var>attribute</var>'s
+ <a href="#attribute-local-name">local name</a>, <var>attribute</var>'s <a href="#attribute-value">value</a>, <var>value</var>, and
+ <var>attribute</var>'s <a href="#attribute-namespace">namespace</a>.
 
- <li><p>An <a>attribute is removed</a>.
+ <li><p>Remove <var>attribute</var> from the <var>element</var>'s <a for=Element>attribute list</a>.
+
+ <li>Set <var>attribute</var>'s <a for=Attr>element</a> to null.
 </ol>
 
 <p>To <dfn id="element-attributes-remove-by-name">remove an attribute by name</dfn>
@@ -2673,9 +2662,9 @@ claims as to whether using them is conforming or not.
 
 <hr>
 
-<p>A <a>node</a>'s <a>parent</a> of type <code><a href="#dom-element">Element</a></code> is known as a <dfn>parent element</dfn>. If the <a>node</a> has a <a>parent</a> of a different type, its <a>parent element</a> is null.</p>
+<p>A <a href="#concept-node">node</a>'s <a>parent</a> of type <code>{{Element}}</code> is known as a <dfn>parent element</dfn>. If the <a href="#concept-node">node</a> has a <a>parent</a> of a different type, its <a>parent element</a> is null.</p>
 
-<p>The <dfn>document element</dfn> of a <a>document</a> is the <a href="#concept-element">element</a> whose <a>parent</a> is that <a>document</a>, if it exists, and null otherwise.
+<p>The <dfn>document element</dfn> of a <a href="#concept-document">document</a> is the <a href="#concept-element">element</a> whose <a>parent</a> is that <a href="#concept-document">document</a>, if it exists, and null otherwise.
 
 <p class="note">Note: Per the <a>node tree</a> constraints, there can only be one such <a href="#concept-element">element</a>.
 
@@ -2684,27 +2673,26 @@ claims as to whether using them is conforming or not.
 <hr>
 
 <dl>
- <dt><var>namespace</var> = <var>element</var> . <code><a>namespaceURI</a></code>
+ <dt><var ignore>namespace</var> = <var>element</var> . {{Element/namespaceURI}}
  <dd><p>Returns the <a href="#element-namespace">namespace</a>.
 
- <dt><var>prefix</var> = <var>element</var> . <code><a href="#element-prefix">prefix</a></code>
+ <dt><var ignore>prefix</var> = <var>element</var> . {{Element/prefix}}
  <dd><p>Returns the <a href="#element-namespace-prefix">namespace prefix</a>.
 
- <dt><var>localName</var> = <var>element</var> . <code><a href="#element-localname">localName</a></code>
+ <dt><var ignore>localName</var> = <var>element</var> . {{Element/localName}}
  <dd><p>Returns the <a href="#element-local-name">local name</a>.
 
- <dt><var>qualifiedName</var> = <var>element</var> . <code><a>tagName</a></code>
+ <dt><var ignore>qualifiedName</var> = <var>element</var> . {{Element/tagName}}
  <dd><p>If <a href="#element-namespace-prefix">namespace prefix</a> is not null, returns the concatenation of <a href="#element-namespace-prefix">namespace prefix</a>, "<code>:</code>", and <a href="#element-local-name">local name</a>. Otherwise it returns the <a href="#element-local-name">local name</a>. (The return value is uppercased in an <a>HTML document</a>.)
 </dl>
 
-<p>The <dfn id="element-namespaceuri" for="element"><code>namespaceURI</code></dfn> attribute must return the <a>context object</a>'s <a href="#element-namespace">namespace</a>.
+<p>The <dfn attribute for=Element id="element-namespaceuri"><code>namespaceURI</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#element-namespace">namespace</a>.
 
-<p>The <dfn id="element-prefix" for="element"><code>prefix</code></dfn> attribute must return the <a>context object</a>'s <a href="#element-namespace-prefix">namespace prefix</a>.
+<p>The <dfn attribute for=Element id="element-prefix"><code>prefix</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#element-namespace-prefix">namespace prefix</a>.
 
-<p>The <dfn id="element-localname" for="element"><code>localName</code></dfn> attribute must return the <a>context object</a>'s <a href="#element-local-name">local name</a>.
+<p>The <dfn attribute for=Element id="element-localname"><code>localName</code></dfn> attribute's getter must return the <a>context object</a>'s <a href="#element-local-name">local name</a>.
 
-<p>The <dfn><code>tagName</code></dfn> attribute
-must run these steps:
+<p>The <dfn attribute for=Element><code>tagName</code></dfn> attribute's getter must run these steps:
 <ol>
  <li><p>If <a>context object</a>'s <a href="#element-namespace-prefix">namespace prefix</a> is not null, let <var>qualified name</var> be its <a href="#element-namespace-prefix">namespace prefix</a>, followed by a "<code>:</code>" (U+003A), followed by its <a href="#element-local-name">local name</a>. Otherwise, let <var>qualified name</var> be its <a href="#element-local-name">local name</a>.
 
@@ -2727,21 +2715,21 @@ must run these steps:
     <p><a>Set an attribute value</a> for the <a>context object</a> using <var>name</var> and the given value.
 </dl>
 
-<p>The <dfn id="element-id" for="element"><code>id</code></dfn> <a>attribute</a> must <a>reflect</a> the "<code>id</code>" content attribute.
+<p>The <dfn attribute for=Element id="element-id"><code>id</code></dfn> attribute must <a>reflect</a> the "<code>id</code>" content attribute.
 
-<p>The <dfn><code>className</code></dfn> attribute must <a>reflect</a> the "<code>class</code>" content attribute.
+<p>The <dfn attribute for=Element><code>className</code></dfn> attribute must <a>reflect</a> the "<code>class</code>" content attribute.
 
-<p>The <dfn><code>classList</code></dfn> attribute must return the associated <code><a>DOMTokenList</a></code> object representing the <a>context object</a>'s <a>classes</a>.
+<p>The <dfn attribute for=Element><code>classList</code></dfn> attribute's getter must return the associated <code>{{DOMTokenList}}</code> object representing the <a>context object</a>'s <a>classes</a>.
 
 <hr>
 
 <p>The <dfn method for=Element><code>hasAttributes()</code></dfn> method, when invoked, must return
-false if <a>context object</a>'s <a href="#attribute-list">attribute list</a> is empty, and
+false if <a>context object</a>'s <a for=Element>attribute list</a> is empty, and
 true otherwise.
 
-<p>The <dfn id="element-attributes" for="element"><code>attributes</code></dfn> attribute must return a <code> {{NamedNodeMap}}</code>.
+<p>The <dfn attribute for=Element id="element-attributes"><code>attributes</code></dfn> attribute's getter must return a <code> {{NamedNodeMap}}</code>.
 
-<p>The <dfn><code>getAttribute(<var>qualifiedName</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Element><code>getAttribute(<var>qualifiedName</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
@@ -2753,21 +2741,21 @@ true otherwise.
  <li><p>Return <var>attr</var>'s <a href="#attribute-value">value</a>.
 </ol>
 
-<p>The <dfn><code>getAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method must return the following steps:
+<p>The <dfn method for=Element><code>getAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked, must return the following steps:
 <ol>
   <li><p>If <var>namespace</var> is the empty string, set it to null.
 
   <li><p>Return <a href="#element-attributes-get-by-name">getting an attribute</a> for the <a>context object</a> using <var>localName</var> and <var>namespace</var>.
 </ol>
 
-<p>The <dfn><code>setAttribute(<var>qualifiedName</var>, <var>value</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Element><code>setAttribute(<var>qualifiedName</var>, <var>value</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>name</var> does not match the <code><a href="http://www.w3.org/TR/xml/#NT-QName">QName</a></code> production in XML, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
+ <li><p>If <var>name</var> does not match the <code><a type>QName</a></code> production in XML, <a>throw</a> an "<code><a>InvalidCharacterError</a></code>".
 
  <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its <a>node document</a> is an <a>HTML document</a>, let <var>qualifiedName</var> be <a>converted to ASCII lowercase</a>.
 
- <li><p>Let <var>attribute</var> be the first <a href="#concept-attribute">attribute</a> in the <a>context object</a>'s <a>attribute list</a> whose <a href="#attribute-name">name</a> is <var>qualifiedName</var>, or null if there is no such <a href="#concept-attribute">attribute</a>.
+ <li><p>Let <var>attribute</var> be the first <a href="#concept-attribute">attribute</a> in the <a>context object</a>'s <a for=Element>attribute list</a> whose <a href="#attribute-name">name</a> is <var>qualifiedName</var>, or null if there is no such <a href="#concept-attribute">attribute</a>.
 
  <li><p>If <var>attribute</var> is null, create an <a href="#concept-attribute">attribute</a> whose <a href="#attribute-local-name">local name</a> is <var>qualifiedName</var>, <a href="#attribute-value">value</a> is <var>value</var>,
 and <a href="#node-document">node document</a> is <a>context object</a>'s <a href="#node-document">node document</a>,
@@ -2776,7 +2764,7 @@ and <a href="#node-document">node document</a> is <a>context object</a>'s <a hre
  <li><p><a>Change</a> <var>attribute</var> from <a>context object</a> to <var>value</var>.
 </ol>
 
-<p>The <dfn><code>setAttributeNS(<var>namespace</var>, <var>qualifiedName</var>, <var>value</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Element><code>setAttributeNS(<var>namespace</var>, <var>qualifiedName</var>, <var>value</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of
@@ -2787,22 +2775,22 @@ and <a href="#node-document">node document</a> is <a>context object</a>'s <a hre
  <var>value</var>, and also <var>prefix</var> and <var>namespace</var>.
 </ol>
 
-<p>The <dfn><code>removeAttribute(<var>qualifiedName</var>)</code></dfn>
+<p>The <dfn method for=Element><code>removeAttribute(<var>qualifiedName</var>)</code></dfn>
 method, when invoked, must <a lt="remove an attribute by name">remove an attribute</a> given
 <var>qualifiedName</var> and the <a>context object</a>, and then return undefined.
 
-<p>The <dfn><code>removeAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method must
+<p>The <dfn method for=Element><code>removeAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked, must
 <a href="#element-attributes-remove-by-namespace">remove an attribute</a> given <var>namespace</var>,
 <var>localName</var>, and <a>context object</a>, and then return undefined.
 
-<p>The <dfn><code>hasAttribute(<var>name</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Element><code>hasAttribute(<var>name</var>)</code></dfn> method, when invoked, must run these steps:
 <ol>
  <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its <a>node document</a> is an <a>HTML document</a>, let <var>name</var> be <a>converted to ASCII lowercase</a>.
 
  <li><p>Return true if the <a>context object</a> <a>has</a> an <a href="#concept-attribute">attribute</a> whose <a href="#attribute-qualified-name">qualifiedName</a> is <var>qualifiedName</var>, and false otherwise.
 </ol>
 
-<p>The <dfn><code>hasAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Element><code>hasAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>namespace</var> is the empty string, set it to null.
@@ -2813,11 +2801,11 @@ method, when invoked, must <a lt="remove an attribute by name">remove an attribu
 <hr>
 
 <dl>
- <dt><code><var>element</var> . {{closest(selectors)}}</code>
+ <dt><code><var>element</var> . {{Element/closest(selectors)}}</code>
  <dd>Returns the first (starting at <var>element</var>) <a>inclusive ancestor</a> that matches <var>selectors</var>, and null otherwise.
 
- <dt><code><var>element</var> . {{matches(selectors)}}</code>
- <dd>Returns true if matching <var>selectors</var> against <var>element</var>'s <a>root</a> yields <var>element</var>, and false otherwise.
+ <dt><code><var>element</var> . {{Element/matches(selectors)}}</code>
+ <dd>Returns true if matching <var>selectors</var> against <var>element</var>'s <a href="#tree-root">root</a> yields <var>element</var>, and false otherwise.
 </dl>
 
 The <dfn method for=Element><code>closest(<var>selectors</var>)</code></dfn>
@@ -2847,22 +2835,22 @@ The <dfn method for=Element><code>matches(<var>selectors</var>)</code></dfn> and
 </ol>
 
 <hr>
-<p>The <dfn><code>getAttributeNode(<var>name</var>)</code></dfn> method, when invoked, must return the result of
+<p>The <dfn method for=Element><code>getAttributeNode(<var>name</var>)</code></dfn> method, when invoked, must return the result of
 <a href="#element-attributes-get-by-name">getting an attribute</a> given <var>qualifiedName</var> and the <a>context object</a>.
 
-<p>The <dfn><code>getAttributeNodeNS(<var>namespace</var>, <var>localName)</var></code></dfn> method, when invoked,
+<p>The <dfn method for=Element><code>getAttributeNodeNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked,
 must return the result of <a href="#element-attributes-get-by-namespace">getting an attribute</a> given
 <var>namespace</var>, <var>localName</var>, and the <a>context object</a>.
 
-<p>The <dfn><code>setAttributeNode(<var>attr</var>)</code></dfn> and <dfn><code>settAttributeNodeNS(<var>attr</var>)</code></dfn> method,
+<p>The <dfn method for=Element><code>setAttributeNode(<var>attr</var>)</code></dfn> and <dfn><code>settAttributeNodeNS(<var>attr</var>)</code></dfn> method,
 when invoked, must return the result of <a href="#element-attributes-set-by-attr">setting an attribute</a> given
 <var>attr</var> and the <a>context object</a>.
 
-<p>The <dfn><code>removeAttributeNode(<var>attr</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=Element><code>removeAttributeNode(<var>attr</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s attribute list doesn't contain <var>attr</var>,
- <a href="#attribute-list">attribute list</a>, <a>throw</a> a {{NotFoundError}}.
+ <li><p>If <a>context object</a>'s <a for=Element>attribute list</a> doesn't contain <var>attr</var>,
+ <a for=Element>attribute list</a>, <a>throw</a> a {{NotFoundError}}.
 
  <li><p><a href="#element-attributes-remove-by-name">Remove</a> <var>attr</var> from <a>context object</a>.
 
@@ -2871,16 +2859,16 @@ when invoked, must return the result of <a href="#element-attributes-set-by-attr
 
 <hr>
 
-<p>The <dfn id="element-getelementsbytagname-func" for="element"><code>getElementsByTagName(<var>localName</var>)</code></dfn> method must return the <a>list of elements with local name <var>localName</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Element id="element-getelementsbytagname-func"><code>getElementsByTagName(<var>localName</var>)</code></dfn> method, when invoked, must return the <a>list of elements with local name <var>localName</var></a> for the <a>context object</a>.
 
-<p>The <dfn id="element-getelementsbytagnamens-func" for="element"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method must return the <a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Element id="element-getelementsbytagnamens-func"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn> method, when invoked, must return the <a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for the <a>context object</a>.
 
-<p>The <dfn id="element-getelementsbyclassname-func" for="element"><code>getElementsByClassName(<var>classNames</var>)</code></dfn> method must return the <a>list of elements with class names <var>classNames</var></a> for the <a>context object</a>.
+<p>The <dfn method for=Element id="element-getelementsbyclassname-func"><code>getElementsByClassName(<var>classNames</var>)</code></dfn> method, when invoked, must return the <a>list of elements with class names <var>classNames</var></a> for the <a>context object</a>.
 
 <hr>
 
 <p>To <dfn>insert adjacent</dfn>, given an <a for=/>element</a> <var>element</var>, string
-<var>where</var>, and a <a>node</a> <var>node</var>, run the steps associated with the first
+<var>where</var>, and a <a href="#concept-node">node</a> <var>node</var>, run the steps associated with the first
 <a>ASCII case-insensitive</a> match for <var>where</var>:
 
 <dl class=switch>
@@ -2944,35 +2932,29 @@ interface NamedNodeMap {
 };
 </pre>
 
-A {{NamedNodeMap}} has an associated
-<dfn export id=concept-namednodemap-element for=NamedNodeMap>element</dfn> (an
+A {{NamedNodeMap}} has an associated <dfn export id=concept-namednodemap-element for=NamedNodeMap>element</dfn> (an
 <a href="#concept-element">element</a>).
 
-A {{NamedNodeMap}} object's
-<dfn export id=concept-namednodemap-attribute for=NamedNodeMap>attribute list</dfn> is its
-<a href="#concept-namednodemap-element">element</a>'s
-<a href="#attribute-list">attribute list</a>.
+A {{NamedNodeMap}} object's <dfn export id=concept-namednodemap-attribute for=NamedNodeMap>attribute list</dfn> is its
+<a href="#concept-namednodemap-element">element</a>'s <a for=Element>attribute list</a>.
 
 <hr>
 
-A {{NamedNodeMap}} object's
-<a>supported property indices</a> are the numbers in the
-range zero to the number of <a>attributes</a> in its
-<a href="#concept-namednodemap-attribute">attribute list</a> map minus one, unless the
-<a href="#concept-namednodemap-attribute">attribute list</a> is empty, in which case
+A {{NamedNodeMap}} object's <a>supported property indices</a> are the numbers in the range zero to the number of <a href="#concept-attribute">attributes</a> in its
+<a href="#concept-namednodemap-attribute">attribute list</a> map minus one, unless the <a href="#concept-namednodemap-attribute">attribute list</a> is empty, in which case
 there are no <a>supported property indices</a>.
 
-<p>The <dfn attribute for="NamedNodeMap"><code>length</code></dfn> attribute's getter must return
-the number of <a>attributes</a> in the <a for=NamedNodeMap>attribute list</a>.
+<p>The <dfn attribute for=NamedNodeMap><code>length</code></dfn> attribute's getter must return
+the number of <a href="#concept-attribute">attributes</a> in the <a for=NamedNodeMap>attribute list</a>.
 
-<p>The <dfn method for="NamedNodeMap"><code>item(<var>index</var>)</code></dfn> method, when
+<p>The <dfn method for=NamedNodeMap><code>item(<var>index</var>)</code></dfn> method, when
 invoked, must run these steps:
 
 <ol>
- <li><p>If <var>index</var> is equal to or greater than the number of <a>attributes</a> in the
+ <li><p>If <var>index</var> is equal to or greater than the number of <a href="#concept-attribute">attributes</a> in the
  <a for=NamedNodeMap>attribute list</a>, return null.
 
- <li><p>Otherwise, return the <var>index</var>th <a>attribute</a> in the
+ <li><p>Otherwise, return the <var>index</var>th <a href="#concept-attribute">attribute</a> in the
  <a for=NamedNodeMap>attribute list</a>.
 </ol>
 
@@ -2980,7 +2962,7 @@ invoked, must run these steps:
 steps:
 
 <ol>
- <li><p>Let <var>names</var> be the <a href="#attribute-qualified-name">qualified names</a> of the <a>attributes</a> in this
+ <li><p>Let <var>names</var> be the <a href="#attribute-qualified-name">qualified names</a> of the <a href="#concept-attribute">attributes</a> in this
  {{NamedNodeMap}} object's <a for=NamedNodeMap>attribute list</a>, with duplicates omitted, in
  order.
  <!-- Even though not all names that map to an attribute are listed, due to lowercasing, ECMAScript
@@ -3002,28 +2984,22 @@ steps:
  <li><p>Return <var>names</var>.
 </ol>
 
-<p>The <dfn method for="NamedNodeMap"><code>getNamedItem(<var>qualifiedName</var>)</code></dfn>
+<p>The <dfn method for=NamedNodeMap><code>getNamedItem(<var>qualifiedName</var>)</code></dfn>
 method, when invoked, must return the result of
 <a lt="get an attribute by name">getting an attribute</a> given <var>qualifiedName</var> and
 <a for=NamedNodeMap>element</a>.
 
-<p>The
-<dfn method for="NamedNodeMap"><code>getNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must return the result of
-<a lt="get an attribute by namespace and local name">getting an attribute</a> given
-<var>namespace</var>, <var>localName</var>, and
-<a for=NamedNodeMap>element</a>.
+<p>The <dfn method for=NamedNodeMap><code>getNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
+method, when invoked, must return the result of <a lt="get an attribute by namespace and local name">getting an attribute</a> given
+<var>namespace</var>, <var>localName</var>, and <a for=NamedNodeMap>element</a>.
 
-<p>The <dfn method for="NamedNodeMap"><code>setNamedItem(<var>attr</var>)</code></dfn> and
-<dfn method for="NamedNodeMap"><code>setNamedItemNS(<var>attr</var>)</code></dfn>
+<p>The <dfn method for=NamedNodeMap><code>setNamedItem(<var>attr</var>)</code></dfn> and <dfn method for="NamedNodeMap"><code>setNamedItemNS(<var>attr</var>)</code></dfn>
 methods, when invoked, must return the result of <a lt="set an attribute">setting an attribute</a> given <var>attr</var> and <a for=NamedNodeMap>element</a>. Rethrow any exceptions.
 
-<p>The <dfn method for="NamedNodeMap"><code>removeNamedItem(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn method for=NamedNodeMap><code>removeNamedItem(<var>qualifiedName</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>attr</var> be the result of
- <a lt="remove an attribute by name">removing an attribute</a> given
+ <li><p>Let <var>attr</var> be the result of  <a lt="remove an attribute by name">removing an attribute</a> given
  <var>qualifiedName</var> and <a for=NamedNodeMap>element</a>.
 
  <li><p>If <var>attr</var> is null, then <a>throw</a> a {{NotFoundError}}.
@@ -3031,8 +3007,7 @@ method, when invoked, must run these steps:
  <li><p>Return <var>attr</var>.
 </ol>
 
-<p>The
-<dfn method for="NamedNodeMap"><code>removeNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
+<p>The <dfn method for=NamedNodeMap><code>removeNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
@@ -3045,7 +3020,7 @@ method, when invoked, must run these steps:
  <li><p>Return <var>attr</var>.
 </ol>
 
-<h4 id="interface-attr">Interface <code><a>Attr</a></code></h4>
+<h4 id="interface-attr">Interface <code>{{Attr}}</code></h4>
 <pre class='idl'>
 [Exposed=Window]
 interface Attr : Node {
@@ -3062,33 +3037,33 @@ interface Attr : Node {
 };
 </pre>
 
-<p><code><a href="#attr">Attr</a></code> <a href="#node">nodes</a> are simply known as <dfn id="concept-attribute" for="attribute">attributes</dfn>. They are sometimes referred to as <em>content attributes</em> to avoid confusion with IDL attributes.
+<p><code>{{Attr}}</code> <a href="#concept-node">nodes</a> are simply known as <dfn id="concept-attribute" for="attribute">attributes</dfn>. They are sometimes referred to as <em>content attributes</em> to avoid confusion with IDL attributes.
 
 <p><a href="#concept-attribute">Attributes</a> have a <dfn id="attribute-namespace" for="attribute">namespace</dfn> (null or a non-empty string), <dfn id="attribute-namespace-prefix" for="attribute">namespace prefix</dfn> (null or a non-empty string), <dfn id="attribute-local-name" for="attribute">local name</dfn> (a non-empty string), <dfn id="attribute-name" for="attribute">name</dfn> (a non-empty string), <dfn id="attribute-value" for="attribute">value</dfn> (a string), and <dfn id="attribute-element" for="attribute">element</dfn> (null or an <a href="#concept-element">element</a>).
 
 <p class="note">Note: If designed today they would just have a name and value.
 
-<p>An <a>attribute</a>'s
+<p>An <a href="#concept-attribute">attribute</a>'s
 <dfn id="attribute-qualified-name">qualified name</dfn> is its
-<a href="#attribute-name">local name</a> if its <a href="#attribute-namespace-prefix">namespace prefix</a> is null, and its
+<a href="#attribute-local-name">local name</a> if its <a href="#attribute-namespace-prefix">namespace prefix</a> is null, and its
 <a href="#attribute-namespace-prefix">namespace prefix</a>, followed by "<code>:</code>", followed by its
 <a href="#attribute-local-name">local name</a>, otherwise.
 
 <p>When an <a href="#concept-attribute">attribute</a> is created, its <a href="#attribute-local-name">local name</a> and <a href="#attribute-value">value</a> are always given. Unless explicitly given when an <a href="#concept-attribute">attribute</a> is created, its <a href="#attribute-name">name</a> is identical to its <a href="#attribute-local-name">local name</a>, and its <a href="#attribute-namespace">namespace</a> and <a href="#attribute-namespace-prefix">namespace prefix</a> are null.
 
-<p>An <dfn id="named-attribute" for="named"><code><var>A</var></code> attribute</dfn> is an <a href="#concept-attribute">attribute</a> whose <a href="#attribute-local-name">local name</a> is <code><var>A</var></code> and whose <a href="#attribute-namespace">namespace</a> and <a href="#attribute-namespace-prefix">namespace prefix</a> are null.
+<p>An <dfn id="named-attribute"><code><var>A</var></code> attribute</dfn> is an <a href="#concept-attribute">attribute</a> whose <a href="#attribute-local-name">local name</a> is <code><var>A</var></code> and whose <a href="#attribute-namespace">namespace</a> and <a href="#attribute-namespace-prefix">namespace prefix</a> are null.
 
-<p>The <dfn id="attr-namespaceuri" for="attr"><code>namespaceURI</code></dfn> attribute's getter must return the <a href="#attribute-namespace">namespace</a>.
+<p>The <dfn attribute for=Attr><code>namespaceURI</code></dfn> attribute's getter must return the <a href="#attribute-namespace">namespace</a>.
 
-<p>The <dfn id="attr-prefix" for="attr"><code>prefix</code></dfn> attribute's getter must return the <a href="#attribute-namespace-prefix">namespace prefix</a>.
+<p>The <dfn attribute for=Attr><code>prefix</code></dfn> attribute's getter must return the <a href="#attribute-namespace-prefix">namespace prefix</a>.
 
-<p>The <dfn id="attr-localname" for="attr"><code>localName</code></dfn> attribute's getter must return the <a href="#attribute-local-name">local name</a>.
+<p>The <dfn attribute for=Attr><code>localName</code></dfn> attribute's getter must return the <a href="#attribute-local-name">local name</a>.
 
-<p>The <dfn id="attr-name"  for="attr"><code>name</code></dfn> attribute's getter and <dfn id="attr-nodename" for="attr"><code>nodeName</code></dfn> attribute's getter must return the <a href="#attribute-name">name</a>.
+<p>The <dfn attribute for=Attr><code>name</code></dfn> attribute's getter and <dfn attribute id="attr-nodename" for=Attr><code>nodeName</code></dfn> attribute's getter must return the <a href="#attribute-name">name</a>.
 
-<p>The <dfn id="attr-value" for="attr"><code>value</code></dfn> attribute's getter must both return the <a href="#attribute-value">value</a>.
+<p>The <dfn attribute for=Attr><code>value</code></dfn> attribute's getter must both return the <a href="#attribute-value">value</a>.
 
-<p>To <dfn>set an existing attribute value</dfn>, given an <a>attribute</a> <var>attribute</var> and
+<p>To <dfn>set an existing attribute value</dfn>, given an <a href="#concept-attribute">attribute</a> <var>attribute</var> and
 string <var>value</var>, run these steps:
 
 <ol>
@@ -3105,9 +3080,9 @@ string <var>value</var>, run these steps:
 <p>The <dfn attribute for="Attr"><code>ownerElement</code></dfn> attribute's getter must return
 <a>context object</a>'s <a href="#attribute-element">element</a>.
 
-<p>The <dfn><code>specified</code></dfn> attribute must return true.
+<p>The <dfn attribute for="Attr"><code>specified</code></dfn> attribute's getter must return true.
 
-<h3 id="nodes-interface-characterdata">Interface <code><a>CharacterData</a></code></h3>
+<h3 id="nodes-interface-characterdata">Interface <code>{{CharacterData}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -3122,9 +3097,9 @@ interface CharacterData : Node {
 };
 </pre>
 
-<p class="note">Note: <code><dfn>CharacterData</dfn></code> is an abstract interface and does not exist as <a>node</a>. It is used by <code><a>Text</a></code>, <code><a>Comment</a></code>, and <code><a>ProcessingInstruction</a></code> <a>nodes</a>.
+<p class="note">Note: <code>{{CharacterData}}</code> is an abstract interface and does not exist as <a href="#concept-node">node</a>. It is used by <code>{{Text}}</code>, <code>{{Comment}}</code>, and <code>{{ProcessingInstruction}}</code> <a>nodes</a>.
 
-<p>Each <a>node</a> inheriting from the <code><a>CharacterData</a></code> interface has an associated mutable string called <dfn id="cd-data" for="cd">data</dfn>.
+<p>Each <a href="#concept-node">node</a> inheriting from the <code>{{CharacterData}}</code> interface has an associated mutable string called <dfn id="cd-data" for="cd">data</dfn>.
 
 <p>To <dfn>replace data</dfn> of node <var>node</var> with offset <var>offset</var>, count <var>count</var>, and data <var>data</var>, run these steps:</p>
 
@@ -3135,7 +3110,7 @@ interface CharacterData : Node {
 
  <li><p>If <var>offset</var> plus <var>count</var> is greater than <var>length</var> let <var>count</var> be <var>length</var> minus <var>offset</var>.
 
- <li><p><a>Queue a mutation record</a> of "<code><a>characterData</a></code>" for <var>node</var> with oldValue <var>node</var>'s <a href="#cd-data">data</a>.
+ <li><p><a>Queue a mutation record</a> of "<code>characterData</code>" for <var>node</var> with oldValue <var>node</var>'s <a href="#cd-data">data</a>.
 
  <li><p>Insert <var>data</var> into <var>node</var>'s <a href="#cd-data">data</a> after <var>offset</var> <a>code units</a>.
 
@@ -3143,16 +3118,16 @@ interface CharacterData : Node {
 
  <li><p>Starting from <var>delete offset</var> <a>code units</a>, remove <var>count</var> <a>code units</a> from <var>node</var>'s <a href="#cd-data">data</a>.
 
- <li><p>For each <a>range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a>start offset</a> to <var>offset</var>.
+ <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a>start offset</a> to <var>offset</var>.
 
- <li><p>For each <a>range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a>end offset</a> to <var>offset</var>.
+ <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a>end offset</a> to <var>offset</var>.
 
- <li><p>For each <a>range</a> whos <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a>start offset</a> by the number of <a>code units</a> in <var>data</var>, then decrease it by <var>count</var>.
+ <li><p>For each <a href="#concept-range">range</a> whos <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a>start offset</a> by the number of <a>code units</a> in <var>data</var>, then decrease it by <var>count</var>.
 
- <li><p>For each <a>range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a>end offset</a> by the number of <a>code units</a> in <var>data</var>, then decrease it by <var>count</var>.
+ <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a>end offset</a> by the number of <a>code units</a> in <var>data</var>, then decrease it by <var>count</var>.
 </ol>
 
-<p>To <dfn>substring data</dfn> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>, run these steps:
+<p>To <dfn lt="substringing data | substring data">substring data</dfn> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>, run these steps:
 
 <ol>
  <li><p>Let <var>length</var> be <var>node</var>'s <a href="#node-length">length</a>.
@@ -3164,21 +3139,21 @@ interface CharacterData : Node {
  <li><p>Return a string whose value is the <a>code units</a> from the <var>offset</var><sup>th</sup> <a>code unit</a> to the <var>offset</var>+<var>count</var><sup>th</sup> <a>code unit</a> in <var>node</var>'s <a href="#cd-data">data</a>.
 </ol>
 
-<p>The <dfn id="characterdata-data" for="characterdata"><code>data</code></dfn> attribute must return <a href="#cd-data">data</a>, and on setting, must <a>replace data</a> with node <a>context object</a> offset 0, count <a>context object</a>'s <a href="#node-length">length</a>, and data new value.
+<p>The <dfn attribute id="characterdata-data" for=CharacterData><code>data</code></dfn> attribute's getter must return <a href="#cd-data">data</a>, and on setting, must <a>replace data</a> with node <a>context object</a> offset 0, count <a>context object</a>'s <a href="#node-length">length</a>, and data new value.
 
-<p>The <dfn id="characterdata-length" for="characterdata"><code>length</code></dfn> attribute must return <a>context object</a>'s <a href="#node-length">length</a>.
+<p>The <dfn attribute id="characterdata-length" for=CharacterData><code>length</code></dfn> attribute's getter must return <a>context object</a>'s <a href="#node-length">length</a>.
 
-<p>The <dfn><code>substringData(<var>offset</var>, <var>count</var>)</code></dfn> method must <a>substring data</a> with node <a>context object</a>, offset <var>offset</var>, and count <var>count</var>.
+<p>The <dfn method for=CharacterData><code>substringData(<var>offset</var>, <var>count</var>)</code></dfn> method, when invoked, must <a>substring data</a> with node <a>context object</a>, offset <var>offset</var>, and count <var>count</var>.
 
-<p>The <dfn><code>appendData(<var>data</var>)</code></dfn> method must <a>replace data</a> with node <a>context object</a>, offset <code><a>context object</a>'s <a href="#node-length">length</a>, count 0, and data <var>data</var>.
+<p>The <dfn method for=CharacterData><code>appendData(<var>data</var>)</code></dfn> method, when invoked, must <a>replace data</a> with node <a>context object</a>, offset <code><a>context object</a>'s <a href="#node-length">length</a>, count 0, and data <var>data</var>.
 
-<p>The <dfn><code>insertData(<var>offset</var>, <var>data</var>)</code></dfn> method must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count 0, and data <var>data</var>.
+<p>The <dfn method for=CharacterData><code>insertData(<var>offset</var>, <var>data</var>)</code></dfn> method, when invoked, must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count 0, and data <var>data</var>.
 
-<p>The <dfn><code>deleteData(<var>offset</var>, <var>count</var>)</code></dfn> method must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count <var>count</var>, and data the empty string.
+<p>The <dfn method for=CharacterData><code>deleteData(<var>offset</var>, <var>count</var>)</code></dfn> method, when invoked, must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count <var>count</var>, and data the empty string.
 
-<p>The <dfn><code>replaceData(<var>offset</var>, <var>count</var>, <var>data</var>)</code></dfn> method must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count <var>count</var>, and data <var>data</var>.
+<p>The <dfn method for=CharacterData><code>replaceData(<var>offset</var>, <var>count</var>, <var>data</var>)</code></dfn> method, when invoked, must <a>replace data</a> with node <a>context object</a>, offset <var>offset</var>, count <var>count</var>, and data <var>data</var>.
 
-<h3 id="nodes-interface-text">Interface <code><a>Text</a></code></h3>
+<h3 id="nodes-interface-text">Interface <code>{{Text}}</code></h3>
 
 <pre class='idl'>
 [Constructor(optional DOMString data = ""),
@@ -3189,33 +3164,33 @@ interface Text : CharacterData {
 };
 </pre>
 
-<p>An <dfn export>exclusive {{Text}} node</dfn> is a {{Text}} <a>node</a> that is not a
-{{CDATASection}} <a>node</a>.
+<p>An <dfn export>exclusive {{Text}} node</dfn> is a {{Text}} <a href="#concept-node">node</a> that is not a
+{{CDATASection}} <a href="#concept-node">node</a>.
 
-<p>The <dfn export>contiguous {{Text}} nodes</dfn> of a <a>node</a> <var>node</var> are
-<var>node</var>, <var>node</var>'s <a>previous sibling</a> {{Text}} <a>node</a>, if any, and its
+<p>The <dfn export>contiguous {{Text}} nodes</dfn> of a <a href="#concept-node">node</a> <var>node</var> are
+<var>node</var>, <var>node</var>'s <a>previous sibling</a> {{Text}} <a href="#concept-node">node</a>, if any, and its
 <a>contiguous <code>Text</code> nodes</a>, and <var>node</var>'s <a for=tree>next sibling</a> {{Text}}
-<a>node</a>, if any, and its <a>contiguous <code>Text</code> nodes</a>, avoiding any duplicates.
+<a href="#concept-node">node</a>, if any, and its <a>contiguous <code>Text</code> nodes</a>, avoiding any duplicates.
 
-<p>The <dfn export>contiguous exclusive {{Text}} nodes</dfn> of a <a>node</a> <var>node</var> are
+<p>The <dfn export>contiguous exclusive {{Text}} nodes</dfn> of a <a href="#concept-node">node</a> <var>node</var> are
 <var>node</var>, <var>node</var>'s <a>previous sibling</a> <a>exclusive <code>Text</code> node</a>,
 if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>node</var>'s
 <a for=tree>next sibling</a> <a>exclusive <code>Text</code> node</a>, if any, and its
 <a>contiguous exclusive <code>Text</code> nodes</a>, avoiding any duplicates.
 <dl>
- <dt><code><var>text</var> = new <a href="#documentfragment">Text</a>([<var>data</var> = ""])</code>
- <dd><p>Returns a new <code><a>Text</a></code> <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
+ <dt><code><var ignore>text</var> = new <a href="#documentfragment">Text</a>([<var>data</var> = ""])</code>
+ <dd><p>Returns a new <code>{{Text}}</code> <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
 
- <dt><code><var>text</var> . <a>splitText</a>(<var>offset</var>)</code>
- <dd><p>Splits <a href="#cd-data">data</a> at the given <var>offset</var> and returns the remainder as <code><a>Text</a></code> <a>node</a>.
+ <dt><code><var>text</var> . {{Text/splitText(offset)}}</code>
+ <dd><p>Splits <a href="#cd-data">data</a> at the given <var>offset</var> and returns the remainder as <code>{{Text}}</code> <a href="#concept-node">node</a>.
 
- <dt><code><var>text</var> . <a>wholeText</a></code>
- <dd><p>Returns the combined <a href="#cd-data">data</a> of all direct <code><a>Text</a></code> <a>node</a> <a>siblings</a>.
+ <dt><code><var>text</var> . {{Text/wholeText}}</code>
+ <dd><p>Returns the combined <a href="#cd-data">data</a> of all direct <code>{{Text}}</code> <a href="#concept-node">node</a> <a>siblings</a>.
 </dl>
 
-<p>The <dfn><code>Text(<var>data</var>)</code></dfn> constructor must return a new <code><a>Text</a></code> <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var> and <a>node document</a> is the global object's associated <a>document</a>.
+<p>The <dfn constructor for=Text><code>Text(<var>data</var>)</code></dfn> constructor must return a new <code>{{Text}}</code> <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var> and <a>node document</a> is the global object's associated <a href="#concept-document">document</a>.
 
-<p>To <dfn>split</dfn> a <code>{{Text}}</code> <a>node</a> <var>node</var> with offset <var>offset</var>, run these steps:
+<p>To <dfn>split</dfn> a <code>{{Text}}</code> <a href="#concept-node">node</a> <var>node</var> with offset <var>offset</var>, run these steps:
 
 <ol>
  <li><p>Let <var>length</var> be <var>node</var>'s <a href="#node-length">length</a>.
@@ -3226,7 +3201,7 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
 
  <li><p>Let <var>new data</var> be the result of <a>substringing data</a> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>.
 
- <li><p>Let <var>new node</var> be a new <code><a>Text</a></code> <a>node</a>, with the same <a>node document</a> as <var>node</var>. Set <var>new node</var>'s <a href="#cd-data">data</a> to <var>new data</var>.
+ <li><p>Let <var>new node</var> be a new <code>{{Text}}</code> <a href="#concept-node">node</a>, with the same <a>node document</a> as <var>node</var>. Set <var>new node</var>'s <a href="#cd-data">data</a> to <var>new data</var>.
 
  <li><p>Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
 
@@ -3234,21 +3209,21 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
   <p>If <var>parent</var> is not null, run these substeps:
 
   <ol>
-   <li><p><a>Insert</a> <var>new node</var> into <var>parent</var> before
+   <li><p><a href="#node-insert">Insert</a> <var>new node</var> into <var>parent</var> before
    <var>node</var>'s <a href="#tree-next-sibling">next sibling</a>.
    <!-- Do this before we replace data, so that the data replacement won't
    mutate ranges prematurely:
    https://www.w3.org/Bugs/Public/show_bug.cgi?id=15325 -->
 
-   <li><p>For each <a>range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var>, set its <a>start node</a> to <var>new node</var> and decrease its <a>start offset</a> by <var>offset</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var>, set its <a>start node</a> to <var>new node</var> and decrease its <a>start offset</a> by <var>offset</var>.
 
-   <li><p>For each <a>range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var>, set its <a>end node</a> to <var>new node</var> and decrease its <a>end offset</a> by <var>offset</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var>, set its <a>end node</a> to <var>new node</var> and decrease its <a>end offset</a> by <var>offset</var>.
 
    <!-- This shit is complicated:
         https://www.w3.org/Bugs/Public/show_bug.cgi?id=19968 -->
-   <li><p>For each <a>range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is equal to the <a>index</a> of <var>node</var> + 1, increase its <a>start offset</a> by one.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>parent</var> and <a>start offset</a> is equal to the <a>index</a> of <var>node</var> + 1, increase its <a>start offset</a> by one.
 
-   <li><p>For each <a>range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is equal to the <a>index</a> of <var>node</var> + 1, increase its <a>end offset</a> by one.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>parent</var> and <a>end offset</a> is equal to the <a>index</a> of <var>node</var> + 1, increase its <a>end offset</a> by one.
   </ol>
 
  <li><p><a>Replace data</a> with node <var>node</var>, offset <var>offset</var>, count <var>count</var>, and data the empty string.
@@ -3257,19 +3232,19 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
   <p>If <var>parent</var> is null, run these substeps:</p>
 
   <ol>
-   <li><p>For each <a>range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var>, set its <a>start offset</a> to <var>offset</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>start node</a> is <var>node</var> and <a>start offset</a> is greater than <var>offset</var>, set its <a>start offset</a> to <var>offset</var>.
 
-   <li><p>For each <a>range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var>, set its <a>end offset</a> to <var>offset</var>.
+   <li><p>For each <a href="#concept-range">range</a> whose <a>end node</a> is <var>node</var> and <a>end offset</a> is greater than <var>offset</var>, set its <a>end offset</a> to <var>offset</var>.
   </ol>
 
  <li><p>Return <var>new node</var>.
 </ol>
 
-<p>The <dfn><code>splitText(<var>offset</var>)</code></dfn> method must <a>split</a> the <a>context object</a> with offset <var>offset</var>.
+<p>The <dfn method for=Text><code>splitText(<var>offset</var>)</code></dfn> method, when invoked, must <a>split</a> the <a>context object</a> with offset <var>offset</var>.
 
 
 
-<p>The <dfn><code>wholeText</code></dfn> attribute must return a concatenation of the <a href="#cd-data">data</a> of the <a>contiguous <code>Text</code> nodes</a> of the <a>context object</a>, in <a>tree order</a>.
+<p>The <dfn attribute for=Text><code>wholeText</code></dfn> attribute's getter must return a concatenation of the <a href="#cd-data">data</a> of the <a>contiguous <code>Text</code> nodes</a> of the <a>context object</a>, in <a>tree order</a>.
 
 <h3 id=interface-cdatasection>Interface {{CDATASection}}</h3>
 
@@ -3278,7 +3253,7 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
 interface CDATASection : Text {
 };</pre>
 
-<h3 id="nodes-interface-processinginstruction">Interface <code><a>ProcessingInstruction</a></code></h3>
+<h3 id="nodes-interface-processinginstruction">Interface <code>{{ProcessingInstruction}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -3287,11 +3262,11 @@ interface ProcessingInstruction : CharacterData {
 };
 </pre>
 
-<p><code><dfn>ProcessingInstruction</dfn></code> <a>nodes</a> have an associated <dfn id="pi-target" for="pi">target</dfn>.
+<p><code>{{ProcessingInstruction}}</code> <a>nodes</a> have an associated <dfn id="pi-target" for="pi">target</dfn>.
 
-<p>The <dfn id="processinginstruction-target" for="processinginstruction"><code>target</code></dfn> attribute must return the <a href="#pi-target">target</a>.
+<p>The <dfn attribute id="processinginstruction-target" for=ProcessingInstruction><code>target</code></dfn> attribute's getter must return the <a href="#pi-target">target</a>.
 
-<h3 id="nodes-interface-comment">Interface <code><a>Comment</a></code></h3>
+<h3 id="nodes-interface-comment">Interface <code>{{Comment}}</code></h3>
 
 <pre class='idl'>
 [Constructor(optional DOMString data = ""),
@@ -3301,9 +3276,9 @@ interface Comment : CharacterData {
 </pre>
 
 <dl>
- <dt><code><var>comment</var> = new <a>Comment</a>([<var>data</var> = ""])</code>
- <dd><p>Returns a new <code><a>Comment</a></code> <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
+ <dt><code><var ignore>comment</var> = new {{Comment}}([<var>data</var> = ""])</code>
+ <dd><p>Returns a new <code>{{Comment}}</code> <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var>.
 </dl>
 
-<p>The <dfn><code>Comment(<var>data</var>)</code></dfn> constructor must return a new <code><a>Comment</a></code> <a>node</a> whose <a href="#cd-data">data</a> is <var>data</var> and <a>node document</a> is the global object's associated <a>document</a>.
+<p>The <dfn constructor for=Comment><code>Comment(<var>data</var>)</code></dfn> constructor must return a new <code>{{Comment}}</code> <a href="#concept-node">node</a> whose <a href="#cd-data">data</a> is <var>data</var> and <a>node document</a> is the global object's associated <a href="#concept-document">document</a>.
 </section>

--- a/sections/ranges.include
+++ b/sections/ranges.include
@@ -3,25 +3,25 @@
 
 <h3 id="ranges-introduction-to-dom-ranges">Introduction to "DOM Ranges"</h3>
 
-  A <code><a>Range</a></code> object (<a>range</a>) represents a sequence of content within a <a>node tree</a>. Each <a>range</a> has a <a>start</a> and an <a>end</a> which are <a>boundary points</a>. A <a>boundary point</a> is a tuple consisting of a <a>node</a> and a non-negative numeric <a>offset</a>. So in other words, a <a>range</a> represents a piece of content within a <a>node tree</a> between two <a>boundary points</a>.
+  A <code>{{Range}}</code> object (<a href="#concept-range">range</a>) represents a sequence of content within a <a>node tree</a>. Each <a href="#concept-range">range</a> has a <a>start</a> and an <a>end</a> which are <a>boundary points</a>. A <a>boundary point</a> is a tuple consisting of a <a href="#concept-node">node</a> and a non-negative numeric <a>offset</a>. So in other words, a <a href="#concept-range">range</a> represents a piece of content within a <a>node tree</a> between two <a>boundary points</a>.
 
-  <a>Ranges</a> are frequently used in editing for selecting and copying content.
+  <a href="#concept-range">Ranges</a> are frequently used in editing for selecting and copying content.
 
 <ul class="domTree">
  <li class="t1"><a>Element</a>: <code>p</code>
   <ul>
-   <li class="t1"><a>Element</a>: <code>img</code> <span class="t2"><code>src</code>="<code>insanity-wolf</code>"</span> <span><code>alt</code>="<code>Little-endian BOM; decode as big-endian!</code>"</span> 
-   <li class="t3"><code><a>Text</a></code>: <span> CSS 2.1 syndata is </span>
+   <li class="t1"><a>Element</a>: <code>img</code> <span class="t2"><code>src</code>="<code>insanity-wolf</code>"</span> <span><code>alt</code>="<code>Little-endian BOM; decode as big-endian!</code>"</span>
+   <li class="t3"><code>{{Text}}</code>: <span> CSS 2.1 syndata is </span>
    <li class="t1"><a>Element</a>: <code>em</code>
     <ul>
-     <li class="t3"><code><a>Text</a></code>: <span>awesome</span>
+     <li class="t3"><code>{{Text}}</code>: <span>awesome</span>
     </ul>
-   <li class="t3"><code><a>Text</a></code>: <span>!</span>
+   <li class="t3"><code>{{Text}}</code>: <span>!</span>
   </ul>
 </ul>
 <!-- http://w3cmemes.tumblr.com/post/35332222321/css-2-1-syndata-is-awesome -->
 
-<p>In the <a>node tree</a> above, a <a>range</a> can be used to represent the sequence “syndata is awes”. Assuming <var>p</var> is assigned to the <code>p</code> <a>element</a>, and <var>em</var> to the <code>em</code> <a>element</a>, this would be done as follows:
+<p>In the <a>node tree</a> above, a <a href="#concept-range">range</a> can be used to represent the sequence “syndata is awes”. Assuming <var ignore>p</var> is assigned to the <code>p</code> <a href="#concept-element">element</a>, and <var ignore>em</var> to the <code>em</code> <a href="#concept-element">element</a>, this would be done as follows:
 
 <pre class='example'><code>var range = new Range(),
     firstText = p.childNodes[1],
@@ -30,13 +30,13 @@ range.setStart(firstText, 9) // do not forget the leading space
 range.setEnd(secondText, 4)
 // range now stringifies to the aforementioned quote</code></pre>
 
-<p class="note">Note: <a>Attributes</a> such as <code>src</code> and <code>alt</code> in the <a>node tree</a> above cannot be represented by a <a>range</a>. The <a>ranges</a> concept is only useful for <a>nodes</a>.
+<p class="note">Note: <a href="#concept-attribute">Attributes</a> such as <code>src</code> and <code>alt</code> in the <a>node tree</a> above cannot be represented by a <a href="#concept-range">range</a>. The <a href="#concept-range">ranges</a> concept is only useful for <a>nodes</a>.
 
-<p><a>Ranges</a> are affected by mutations to the <a>node tree</a>. Such mutations will not invalidate a <a>range</a> and will try to ensure that the <a>range</a> still represents the same piece of content. Necessarily, a <a>range</a> might itself be modified as part of the mutation to the <a>node tree</a> when e.g. part of the content it represents is mutated.
+<p><a href="#concept-range">Ranges</a> are affected by mutations to the <a>node tree</a>. Such mutations will not invalidate a <a href="#concept-range">range</a> and will try to ensure that the <a href="#concept-range">range</a> still represents the same piece of content. Necessarily, a <a href="#concept-range">range</a> might itself be modified as part of the mutation to the <a>node tree</a> when e.g. part of the content it represents is mutated.
 
-<p class="note">Note: See the <a>insert</a> and <a>remove</a> algorithms, the <code><a>normalize()</a></code> method, and the <a>replace data</a> and <a>split</a> algorithms for the hairy details.
+<p class="note">Note: See the <a href="#node-insert">insert</a> and <a href="#node-remove">remove</a> algorithms, the <code><a href="#dom-node-normalize">normalize()</a></code> method, and the <a>replace data</a> and <a>split</a> algorithms for the hairy details.
 
-<h3 id="ranges-interface-range">Interface <code><a>Range</a></code></h3>
+<h3 id="ranges-interface-range">Interface <code>{{Range}}</code></h3>
 
 <pre class='idl'>
 [Constructor,
@@ -83,11 +83,11 @@ interface Range {
 };
 </pre>
 
-<p><code><a>Range</a></code> objects are simply known as <dfn lt="range|ranges">ranges</dfn>.
+<p><code>{{Range}}</code> objects are simply known as <dfn id="concept-range" lt="range|ranges">ranges</dfn>.
 
-<p>A <dfn>boundary point</dfn> is a (<a>node</a>, <dfn lt="range boundary point offset|boundary point offset|offset">offset</dfn>) tuple, where <a>offset</a> is a non-negative integer.
+<p>A <dfn>boundary point</dfn> is a (<a href="#concept-node">node</a>, <dfn lt="range boundary point offset|boundary point offset|offset">offset</dfn>) tuple, where <a>offset</a> is a non-negative integer.
 
-<p class="note">Note: Generally speaking, a <a>boundary point</a>'s <a>offset</a> will be between zero and the <a>boundary point</a>'s <a>node</a> <a>length</a>, inclusive. Algorithms that modify a <a>tree</a> (in particular the <a>insert</a>, <a>remove</a>, <a>replace data</a>, and <a>split</a> algorithms) also modify <a>ranges</a> associated with that <a>tree</a>.
+<p class="note">Note: Generally speaking, a <a>boundary point</a>'s <a>offset</a> will be between zero and the <a>boundary point</a>'s <a href="#concept-node">node</a> <a>length</a>, inclusive. Algorithms that modify a <a>tree</a> (in particular the <a href="#node-insert">insert</a>, <a href="#node-remove">remove</a>, <a>replace data</a>, and <a>split</a> algorithms) also modify <a href="#concept-range">ranges</a> associated with that <a>tree</a>.
 
 <p>If the two <a>nodes</a> of <a>boundary points</a> (<var>node A</var>, <var>offset A</var>) and (<var>node B</var>, <var>offset B</var>) have the same <a href="#tree-root">root</a>, the <dfn lt="range boundary point position|boundary point position|position">position</dfn> of the first relative to the second is either <dfn lt="range boundary point before|boundary point before|before">before</dfn>, <dfn lt="range boundary point equal|boundary point equal|equal">equal</dfn>, or <dfn lt="range boundary point after|boundary point after|after">after</dfn>, as returned by the following algorithm:
 
@@ -111,36 +111,36 @@ interface Range {
 
 </ol>
 
-<p>Each <a>range</a> has two associated <a>boundary points</a> — a <dfn lt="range start|start">start</dfn> and <dfn lt="range end|end">end</dfn>.
+<p>Each <a href="#concept-range">range</a> has two associated <a>boundary points</a> — a <dfn lt="range start|start">start</dfn> and <dfn lt="range end|end">end</dfn>.
 
-<p>For convenience, <dfn lt="range start node|start node">start node</dfn> is <a>start</a>'s <a>node</a>, <dfn>start offset</dfn> is <a>start</a>'s <a>offset</a>, <dfn lt="range end node|end node">end node</dfn> is <a>end</a>'s <a>node</a>, and <dfn>end offset</dfn> is <a>end</a>'s <a>offset</a>.
+<p>For convenience, <dfn lt="range start node|start node">start node</dfn> is <a>start</a>'s <a href="#concept-node">node</a>, <dfn>start offset</dfn> is <a>start</a>'s <a>offset</a>, <dfn lt="range end node|end node">end node</dfn> is <a>end</a>'s <a href="#concept-node">node</a>, and <dfn>end offset</dfn> is <a>end</a>'s <a>offset</a>.
 
 <p>The <dfn id="range-root" for="range">root of a range</dfn> is the <a href="#tree-root">root</a> of its <a>start node</a>.
 <!-- start and end have an identical root -->
 
-<p>A <a>node</a> <var>node</var> is <dfn>contained</dfn> in a <a>range</a> <var>range</var> if <var>node</var>'s <a href="#tree-root">root</a> is the same as <var>range</var>'s <a href="#range-root">root</a>, and (<var>node</var>, 0) is <a>after</a> <var>range</var>'s <a>start</a>, and (<var>node</var>, <a>length</a> of <var>node</var>) is <a>before</a> <var>range</var>'s <a>end</a>.
+<p>A <a href="#concept-node">node</a> <var>node</var> is <dfn>contained</dfn> in a <a href="#concept-range">range</a> <var>range</var> if <var>node</var>'s <a href="#tree-root">root</a> is the same as <var>range</var>'s <a href="#range-root">root</a>, and (<var>node</var>, 0) is <a>after</a> <var>range</var>'s <a>start</a>, and (<var>node</var>, <a>length</a> of <var>node</var>) is <a>before</a> <var>range</var>'s <a>end</a>.
 
-<p>A <a>node</a> is <dfn>partially contained</dfn> in a <a>range</a> if it is an <a>inclusive ancestor</a> of the <a>range</a>'s <a>start node</a> but not its <a>end node</a>, or vice versa.
+<p>A <a href="#concept-node">node</a> is <dfn>partially contained</dfn> in a <a href="#concept-range">range</a> if it is an <a>inclusive ancestor</a> of the <a href="#concept-range">range</a>'s <a>start node</a> but not its <a>end node</a>, or vice versa.
 
 <div class="note">
  <p>Some facts to better understand these definitions:
 
  <ul>
-  <li><p>The content that one would think of as being within the <a>range</a> consists of all <a>contained</a> <a>nodes</a>, plus possibly some of the contents of the <a>start node</a> and <a>end node</a> if those are <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>nodes</a>.
+  <li><p>The content that one would think of as being within the <a href="#concept-range">range</a> consists of all <a>contained</a> <a>nodes</a>, plus possibly some of the contents of the <a>start node</a> and <a>end node</a> if those are <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a>nodes</a>.
 
-  <li><p>The <a>nodes</a> that are contained in a <a>range</a> will generally not be contiguous, because the <a>parent</a> of a <a>contained</a> <a>node</a> will not always be <a>contained</a>.
+  <li><p>The <a>nodes</a> that are contained in a <a href="#concept-range">range</a> will generally not be contiguous, because the <a>parent</a> of a <a>contained</a> <a href="#concept-node">node</a> will not always be <a>contained</a>.
 
-  <li><p>However, the <a>descendants</a> of a <a>contained</a> <a>node</a> are <a>contained</a>, and if two <a>siblings</a> are <a>contained</a>, so are any <a>siblings</a> that lie between them.
+  <li><p>However, the <a>descendants</a> of a <a>contained</a> <a href="#concept-node">node</a> are <a>contained</a>, and if two <a>siblings</a> are <a>contained</a>, so are any <a>siblings</a> that lie between them.
 
-  <li><p>The first <a>contained</a> <a>node</a> (if there are any) will always be after the <a>start node</a>, and the last <a>contained</a> <a>node</a> will always be equal to or before the <a>end node</a>'s last <a>descendant</a>.
+  <li><p>The first <a>contained</a> <a href="#concept-node">node</a> (if there are any) will always be after the <a>start node</a>, and the last <a>contained</a> <a href="#concept-node">node</a> will always be equal to or before the <a>end node</a>'s last <a>descendant</a>.
 
-  <li><p>The <a>start node</a> and <a>end node</a> of a <a>range</a> are never <a>contained</a> within it.
+  <li><p>The <a>start node</a> and <a>end node</a> of a <a href="#concept-range">range</a> are never <a>contained</a> within it.
 
-  <li><p>There exists a partially contained <a>node</a> if and only if the <a>start node</a> and <a>end node</a> are different.
+  <li><p>There exists a partially contained <a href="#concept-node">node</a> if and only if the <a>start node</a> and <a>end node</a> are different.
 
-  <li><p>The <code><a>commonAncestorContainer</a></code> attribute value is neither <a>contained</a> nor <a>partially contained</a>.
+  <li><p>The <code>{{Range/commonAncestorContainer}}</code> attribute value is neither <a>contained</a> nor <a>partially contained</a>.
 
-  <li>If the <a>start node</a> is an <a>ancestor</a> of the <a>end node</a>, the common <a>inclusive ancestor</a> will be the <a>start node</a>. Exactly one of its <a>children</a> will be <a>partially contained</a>, and a <a>child</a> will be <a>contained</a> if and only if it <a>precedes</a> the <a>partially contained</a> <a>child</a>. If the <a>end node</a> is an <a>ancestor</a> of the <a>start node</a>, the opposite holds.
+  <li>If the <a>start node</a> is an <a>ancestor</a> of the <a>end node</a>, the common <a>inclusive ancestor</a> will be the <a>start node</a>. Exactly one of its <a>children</a> will be <a>partially contained</a>, and a <a>child</a> will be <a>contained</a> if and only if it <a href="#preceding">precedes</a> the <a>partially contained</a> <a>child</a>. If the <a>end node</a> is an <a>ancestor</a> of the <a>start node</a>, the opposite holds.
 
   <li><p>If the <a>start node</a> is not an <a>inclusive ancestor</a> of the <a>end node</a>, nor vice versa, the common <a>inclusive ancestor</a> will be distinct from both of them. Exactly two of its <a>children</a> will be <a>partially contained</a>, and a <a>child</a> will be contained if and only if it lies between those two.
  </ul>
@@ -150,48 +150,48 @@ interface Range {
 
 <dl>
 
-  : <code><var>range</var> = new <a>Range</a>()</code>
-  :: Returns a new <a>range</a>.
+  : <code><var>range</var> = new <a constructor>Range()</a></code>
+  :: Returns a new <a href="#concept-range">range</a>.
 
 </dl>
 
-<p>The <dfn><code>Range()</code></dfn> constructor must return a new <a>range</a> with (global object's associated <a>document</a>, 0) as its <a>start</a> and <a>end</a>.
+<p>The <dfn constructor for=Range><code>Range()</code></dfn> constructor must return a new <a href="#concept-range">range</a> with (global object's associated <a href="#concept-document">document</a>, 0) as its <a>start</a> and <a>end</a>.
 
 <hr>
 
 <dl>
 
-  : <var>node</var> = <var>range</var> . <code><a>startContainer</a></code>
+  : <var ignore>node</var> = <var>range</var> . {{Range/startContainer}}
   :: Returns <var>range</var>'s <a>start node</a>.
 
-  : <var>offset</var> = <var>range</var> . <code><a>startOffset</a></code>
+  : <var ignore>offset</var> = <var>range</var> . {{Range/startOffset}}
   :: Returns <var>range</var>'s <a>start offset</a>.
 
-  : <var>node</var> = <var>range</var> . <code><a>endContainer</a></code>
+  : <var ignore>node</var> = <var>range</var> . {{Range/endContainer}}
   :: Returns <var>range</var>'s <a>end node</a>.
 
-  : <var>offset</var> = <var>range</var> . <code><a>endOffset</a></code>
+  : <var ignore>offset</var> = <var>range</var> . {{Range/endOffset}}
   :: Returns <var>range</var>'s <a>end offset</a>.
 
-  : <var>collapsed</var> = <var>range</var> . <code><a>collapsed</a></code>
+  : <var ignore>collapsed</var> = <var>range</var> . {{Range/collapsed}}
   :: Returns true if <var>range</var>'s <a>start</a> and <a>end</a> are the same, and false otherwise.
 
-  : <var>container</var> = <var>range</var> . <code><a>commonAncestorContainer</a></code>
-  :: Returns the <a>node</a>, furthest away from the <a>document</a>, that is an <a>ancestor</a> of both <var>range</var>'s <a>start node</a> and <a>end node</a>.
+  : <var ignore>container</var> = <var>range</var> . {{Range/commonAncestorContainer}}
+  :: Returns the <a href="#concept-node">node</a>, furthest away from the <a href="#concept-document">document</a>, that is an <a>ancestor</a> of both <var>range</var>'s <a>start node</a> and <a>end node</a>.
 
 </dl>
 
-<p>The <dfn><code>startContainer</code></dfn> attribute must return the <a>start node</a>.
+<p>The <dfn attribute for=Range><code>startContainer</code></dfn> attribute's getter must return the <a>start node</a>.
 
-<p>The <dfn><code>startOffset</code></dfn> attribute must return the <a>start offset</a>.
+<p>The <dfn attribute for=Range><code>startOffset</code></dfn> attribute's getter must return the <a>start offset</a>.
 
-<p>The <dfn><code>endContainer</code></dfn> attribute must return the <a>end node</a>.
+<p>The <dfn attribute for=Range><code>endContainer</code></dfn> attribute's getter must return the <a>end node</a>.
 
-<p>The <dfn><code>endOffset</code></dfn> attribute must return the <a>end offset</a>.
+<p>The <dfn attribute for=Range><code>endOffset</code></dfn> attribute's getter must return the <a>end offset</a>.
 
-<p>The <dfn><code>collapsed</code></dfn> attribute must return true if <a>start</a> is the same as <a>end</a>, and false otherwise.
+<p>The <dfn attribute for=Range><code>collapsed</code></dfn> attribute's getter must return true if <a>start</a> is the same as <a>end</a>, and false otherwise.
 
-<p>The <dfn><code>commonAncestorContainer</code></dfn> attribute must run these steps:
+<p>The <dfn attribute for=Range><code>commonAncestorContainer</code></dfn> attribute's getter must run these steps:
 
 <ol>
   1. Let <var>container</var> be <a>start node</a>.
@@ -207,7 +207,7 @@ interface Range {
 <p>To <dfn lt="set the start|set the end">set the start or end</dfn> of a <var>range</var> to a <a>boundary point</a> (<var>node</var>, <var>offset</var>), run these steps:
 
 <ol>
-  <li>If <var>node</var> is a <a>doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
+  <li>If <var>node</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
 
   <li>If <var>offset</var> is greater than <var>node</var>'s <a>length</a>, <a>throw</a> an "<code>IndexSizeError</code>". [[!WEBIDL]]
 
@@ -232,11 +232,11 @@ interface Range {
 </ol>
 
 <p>The
-<dfn><code>setStart(<var>node</var>, <var>offset</var>)</code></dfn> method must <a>set the start</a> of the <a>context object</a> to <a>boundary point</a> (<var>node</var>, <var>offset</var>).
+<dfn method for=Range><code>setStart(<var>node</var>, <var>offset</var>)</code></dfn> method, when invoked, must <a>set the start</a> of the <a>context object</a> to <a>boundary point</a> (<var>node</var>, <var>offset</var>).
 
-<p>The <dfn><code>setEnd(<var>node</var>, <var>offset</var>)</code></dfn> method must <a>set the end</a> of the <a>context object</a> to <a>boundary point</a> (<var>node</var>, <var>offset</var>).
+<p>The <dfn method for=Range><code>setEnd(<var>node</var>, <var>offset</var>)</code></dfn> method, when invoked, must <a>set the end</a> of the <a>context object</a> to <a>boundary point</a> (<var>node</var>, <var>offset</var>).
 
-<p>The <dfn><code>setStartBefore(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>setStartBefore(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
   1. Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
@@ -247,7 +247,7 @@ interface Range {
 
 </ol>
 
-<p>The <dfn><code>setStartAfter(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>setStartAfter(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
   1. Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
@@ -258,7 +258,7 @@ interface Range {
 
 </ol>
 
-<p>The <dfn><code>setEndBefore(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>setEndBefore(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
   1. Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
@@ -269,7 +269,7 @@ interface Range {
 
 </ol>
 
-<p>The <dfn><code>setEndAfter(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>setEndAfter(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
   1. Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
@@ -280,9 +280,9 @@ interface Range {
 
 </ol>
 
-<p>The <dfn><code>collapse(<var>toStart</var>)</code></dfn> method, when invoked, must if <var>toStart</var> is true, set <a>end</a> to <a>start</a>, and set <a>start</a> to <a>end</a> otherwise.
+<p>The <dfn method for=Range><code>collapse(<var>toStart</var>)</code></dfn> method, when invoked, must if <var>toStart</var> is true, set <a>end</a> to <a>start</a>, and set <a>start</a> to <a>end</a> otherwise.
 
-<p>To <dfn lt="range select|select">select</dfn> a <a>node</a> <var>node</var> within a <a>range</a> <var>range</var>, run these steps:
+<p>To <dfn lt="range select|select">select</dfn> a <a href="#concept-node">node</a> <var>node</var> within a <a href="#concept-range">range</a> <var>range</var>, run these steps:
 
 <ol>
   1. Let <var>parent</var> be <var>node</var>'s <a>parent</a>.
@@ -297,12 +297,12 @@ interface Range {
 
 </ol>
 
-<p>The <dfn><code>selectNode(<var>node</var>)</code></dfn> method must <a>select</a> <var>node</var> within <a>context object</a>.
+<p>The <dfn method for=Range><code>selectNode(<var>node</var>)</code></dfn> method, when invoked, must <a>select</a> <var>node</var> within <a>context object</a>.
 
-<p>The <dfn><code>selectNodeContents(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>selectNodeContents(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
-  1. If <var>node</var> is a <a>doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
+  1. If <var>node</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
 
   2. Let <var>length</var> be the <a>length</a> of <var>node</var>.
 
@@ -314,14 +314,14 @@ interface Range {
 
 <hr>
 
-<p>The <dfn><code>compareBoundaryPoints(<var>how</var>, <var>sourceRange</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>compareBoundaryPoints(<var>how</var>, <var>sourceRange</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
   <li>If <var>how</var> is not one of <ul>
-   <li><code><a>START_TO_START</a></code>,
-   <li><code><a>START_TO_END</a></code>,
-   <li><code><a>END_TO_END</a></code>, and
-   <li><code><a>END_TO_START</a></code>,
+   <li><code>{{Range/START_TO_START}}</code>,
+   <li><code>{{Range/START_TO_END}}</code>,
+   <li><code>{{Range/END_TO_END}}</code>, and
+   <li><code>{{Range/END_TO_START}}</code>,
   </ul>
   <p><a>throw</a> a "<code>NotSupportedError</code>". [[!WEBIDL]]
  <li><p>If <a>context object</a>'s <a href="#range-root">root</a> is not the same as <var>sourceRange</var>'s <a href="#range-root">root</a>, <a>throw</a> a "<code>WrongDocumentError</code>". [[!WEBIDL]]
@@ -329,22 +329,22 @@ interface Range {
  <li>
   <p>If <var>how</var> is:
   <dl class="switch">
-   <dt><code><a>START_TO_START</a></code>:
+   <dt><code>{{Range/START_TO_START}}</code>:
    <dd>
     <p>Let <var>this point</var> be the <a>context object</a>'s <a>start</a>.
     <p>Let <var>other point</var> be <var>sourceRange</var>'s <a>start</a>.
 
-   <dt><code><a>START_TO_END</a></code>:
+   <dt><code>{{Range/START_TO_END}}</code>:
    <dd>
     <p>Let <var>this point</var> be the <a>context object</a>'s <a>end</a>.
     <p>Let <var>other point</var> be <var>sourceRange</var>'s <a>start</a>.
 
-    <dt><code><a>END_TO_END</a></code>:
+    <dt><code>{{Range/END_TO_END}}</code>:
     <dd>
      <p>Let <var>this point</var> be the <a>context object</a>'s <a>end</a>.
      <p>Let <var>other point</var> be <var>sourceRange</var>'s <a>end</a>.
 
-    <dt><code><a>END_TO_START</a></code>:
+    <dt><code>{{Range/END_TO_START}}</code>:
     <dd>
      <p>Let <var>this point</var> be the <a>context object</a>'s <a>start</a>.
      <p>Let <var>other point</var> be <var>sourceRange</var>'s <a>end</a>.
@@ -365,7 +365,7 @@ interface Range {
    </dl>
 </ol>
 
-<p>The <dfn><code>deleteContents()</code></dfn>method must run these steps:
+<p>The <dfn method for=Range><code>deleteContents()</code></dfn>method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <a>start</a> is <a>end</a>, terminate these steps.
@@ -376,9 +376,9 @@ interface Range {
 
  <li><p>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be the <a>context object</a>'s <a>start node</a>, <a>start offset</a>, <a>end node</a>, and <a>end offset</a>, respectively.
 
- <li><p>If <var>original start node</var> and <var>original end node</var> are the same, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>, <a>replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string, and then terminate these steps.
+ <li><p>If <var>original start node</var> and <var>original end node</var> are the same, and they are a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>, <a>replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string, and then terminate these steps.
 
- <li><p>Let <var>nodes to remove</var> be a list of all the <a>nodes</a> that are <a>contained</a> in the <a>context object</a>, in <a>tree order</a>, omitting any <a>node</a> whose <a>parent</a> is also <a>contained</a> in the <a>context object</a>.
+ <li><p>Let <var>nodes to remove</var> be a list of all the <a>nodes</a> that are <a>contained</a> in the <a>context object</a>, in <a>tree order</a>, omitting any <a href="#concept-node">node</a> whose <a>parent</a> is also <a>contained</a> in the <a>context object</a>.
 
  <li><p>If <var>original start node</var> is an <a>inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>.
 
@@ -396,19 +396,19 @@ interface Range {
     <p class="note">Note: If <var>reference node</var>'s <a>parent</a> were null, it would be the <a href="#range-root">root</a> of the <a>context object</a>, so would be an <a>inclusive ancestor</a> of <var>original end node</var>, and we could not reach this point.
   </ol>
 
- <li><p>If <var>original start node</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>, <a>replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>'s <a>length</a> minus <var>original start offset</var>, data the empty string.
+ <li><p>If <var>original start node</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>, <a>replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>'s <a>length</a> minus <var>original start offset</var>, data the empty string.
 
- <li><p>For each <var>node</var> in <var>nodes to remove</var>, in <a>tree order</a>, <a>remove</a> <var>node</var> from its <a>parent</a>.
+ <li><p>For each <var>node</var> in <var>nodes to remove</var>, in <a>tree order</a>, <a href="#node-remove">remove</a> <var>node</var> from its <a>parent</a>.
 
- <li><p>If <var>original end node</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>, <a>replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string.
+ <li><p>If <var>original end node</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>, <a>replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string.
 
  <li><p>Set <a>start</a> and <a>end</a> to (<var>new node</var>, <var>new offset</var>).
 </ol>
 
-<p>To <dfn lt="range extract|extract">extract</dfn> a <a>range</a> <var>range</var>, run these steps:
+<p>To <dfn lt="range extract|extract">extract</dfn> a <a href="#concept-range">range</a> <var>range</var>, run these steps:
 
 <ol>
- <li><p>Let <var>fragment</var> be a new <code><a>DocumentFragment</a></code> <a>node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
+ <li><p>Let <var>fragment</var> be a new <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
 
  <li><p>If <var>range</var>'s <a>start</a> is its <a>end</a>, return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
@@ -421,14 +421,14 @@ interface Range {
  <li><p>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>'s <a>start node</a>, <a>start offset</a>, <a>end node</a>, and <a>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>original start node</var>.
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
    <li><p><a>Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string.
 
@@ -453,14 +453,14 @@ interface Range {
  <li><p>Let <var>contained children</var> be a list of all <a>children</a> of <var>common ancestor</var> that are <a>contained</a> in <var>range</var>, in <a>tree order</a>.
 
  <li>
-  <p>If any member of <var>contained children</var> is a <a>doctype</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+  <p>If any member of <var>contained children</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
   <!-- Firefox 4.0 actually removes the non-DocumentType nodes before
   throwing the exception. Opera 11.00 removes the DocumentType too, and
   doesn't throw. I go with IE9 and Chrome 12 dev, which don't remove any
   nodes. DOM 2 Range doesn't specify what exactly happens here, except that
   an exception should be thrown. -->
 
-  <p class="note">Note: We do not have to worry about the first or last partially contained node, because a <a>doctype</a> can never be partially contained. It cannot be a boundary point of a range, and it cannot be the ancestor of anything.
+  <p class="note">Note: We do not have to worry about the first or last partially contained node, because a <a href="#concept-doctype">doctype</a> can never be partially contained. It cannot be a boundary point of a range, and it cannot be the ancestor of anything.
 
  <li><p>If <var>original start node</var> is an <a>inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>.
 
@@ -481,7 +481,7 @@ interface Range {
   anymore unless we carefully consider how it will have mutated. -->
 
  <li>
-  <p>If <var>first partially contained child</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>first partially contained child</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <p class="note">Note: In this case, <var>first partially contained child</var> is <var>original start node</var>.
 
@@ -490,7 +490,7 @@ interface Range {
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>'s <a>length</a> minus <var>original start offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
    <li><p><a>Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>'s <a>length</a> minus <var>original start offset</var>, and data the empty string.
   </ol>
@@ -501,19 +501,19 @@ interface Range {
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>first partially contained child</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
-   <li><p>Let <var>subrange</var> be a new <a>range</a> whose <a>start</a> is (<var>original start node</var>, <var>original start offset</var>) and whose <a>end</a> is (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
+   <li><p>Let <var>subrange</var> be a new <a href="#concept-range">range</a> whose <a>start</a> is (<var>original start node</var>, <var>original start offset</var>) and whose <a>end</a> is (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
 
    <li><p>Let <var>subfragment</var> be the result of <a>extracting</a> <var>subrange</var>.
 
-   <li><p><a>Append</a> <var>subfragment</var> to <var>clone</var>.
+   <li><p><a href="#node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
   </ol>
 
- <li><p>For each <var>contained child</var> in <var>contained children</var>, <a>append</a> <var>contained child</var> to <var>fragment</var>.
+ <li><p>For each <var>contained child</var> in <var>contained children</var>, <a href="#node-append">append</a> <var>contained child</var> to <var>fragment</var>.
 
  <li>
-  <p>If <var>last partially contained child</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>last partially contained child</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <p class="note">Note: In this case, <var>last partially contained child</var> is <var>original end node</var>.
 
@@ -522,7 +522,7 @@ interface Range {
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
    <li><p><a>Replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var>, and data the empty string.
   </ol>
@@ -533,13 +533,13 @@ interface Range {
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>last partially contained child</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
-   <li><p>Let <var>subrange</var> be a new <a>range</a> whose <a>start</a> is (<var>last partially contained child</var>, 0) and whose <a>end</a> is (<var>original end node</var>, <var>original end offset</var>).
+   <li><p>Let <var>subrange</var> be a new <a href="#concept-range">range</a> whose <a>start</a> is (<var>last partially contained child</var>, 0) and whose <a>end</a> is (<var>original end node</var>, <var>original end offset</var>).
 
    <li><p>Let <var>subfragment</var> be the result of <a>extracting</a> <var>subrange</var>.
 
-   <li><p><a>Append</a> <var>subfragment</var> to <var>clone</var>.
+   <li><p><a href="#node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
   </ol>
 
  <li><p>Set <var>range</var>'s <a>start</a> and <a>end</a> to (<var>new node</var>, <var>new offset</var>).
@@ -547,12 +547,12 @@ interface Range {
  <li><p>Return <var>fragment</var>.
 </ol>
 
-<p>The <dfn><code>extractContents()</code></dfn> method must return the result of <a>extracting</a> <a>context object</a>.
+<p>The <dfn method for=Range><code>extractContents()</code></dfn> method, when invoked, must return the result of <a>extracting</a> <a>context object</a>.
 
-<p>To <dfn id="concept-range-clone" lt="clone the contents of a range">clone the contents</dfn> of a <a>range</a> <var>range</var>, run these steps:
+<p>To <dfn id="concept-range-clone" lt="clone the contents of a range">clone the contents</dfn> of a <a href="#concept-range">range</a> <var>range</var>, run these steps:
 
 <ol>
- <li><p>Let <var>fragment</var> be a new <code><a>DocumentFragment</a></code> <a >node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
+ <li><p>Let <var>fragment</var> be a new <code>{{DocumentFragment}}</code> <a >node</a> whose <a>node document</a> is <var>range</var>'s <a>start node</a>'s <a>node document</a>.
 
  <li><p>If <var>range</var>'s <a>start</a> is its <a>end</a>, return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
@@ -565,14 +565,14 @@ interface Range {
  <li><p>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>'s <a>start node</a>, <a>start offset</a>, <a>end node</a>, and <a>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>original start node</var> is <var>original end node</var>, and they are a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>original start node</var>.
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
    <li><p>Return <var>fragment</var>.
   </ol>
@@ -595,14 +595,14 @@ interface Range {
  <li><p>Let <var>contained children</var> be a list of all <a>children</a> of <var>common ancestor</var> that are <a>contained</a> in <var>range</var>, in <a>tree order</a>.
 
  <li>
-  <p>If any member of <var>contained children</var> is a <a>doctype</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
+  <p>If any member of <var>contained children</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> a "<code><a>HierarchyRequestError</a></code>".
 
-  <p class="note">Note: We do not have to worry about the first or last partially contained node, because a <a>doctype</a> can never be
+  <p class="note">Note: We do not have to worry about the first or last partially contained node, because a <a href="#concept-doctype">doctype</a> can never be
   partially contained. It cannot be a boundary point of a range, and it
   cannot be the ancestor of anything.
 
  <li>
-  <p>If <var>first partially contained child</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>first partially contained child</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <p class="note">Note: In this case, <var>first partially contained child</var> is <var>original start node</var>.
 
@@ -611,7 +611,7 @@ interface Range {
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>'s <a>length</a> minus <var>original start offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
   </ol>
 
  <li>
@@ -620,13 +620,13 @@ interface Range {
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>first partially contained child</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
-   <li><p>Let <var>subrange</var> be a new <a>range</a> whose <a>start</a> is (<var>original start node</var>, <var>original start offset</var>) and whose <a>end</a> is (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
+   <li><p>Let <var>subrange</var> be a new <a href="#concept-range">range</a> whose <a>start</a> is (<var>original start node</var>, <var>original start offset</var>) and whose <a>end</a> is (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
 
    <li><p>Let <var>subfragment</var> be the result of <a href="#concept-range-clone">cloning</a> <var>subrange</var>.
 
-   <li><p><a>Append</a> <var>subfragment</var> to <var>clone</var>.
+   <li><p><a href="#node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
   </ol>
 
  <li>
@@ -635,11 +635,11 @@ interface Range {
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>contained child</var> with the <i>clone children flag</i> set.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
   </ol>
 
  <li>
-  <p>If <var>last partially contained child</var> is a <code><a>Text</a></code>, <code><a>ProcessingInstruction</a></code>, or <code><a>Comment</a></code> <a>node</a>:
+  <p>If <var>last partially contained child</var> is a <code>{{Text}}</code>, <code>{{ProcessingInstruction}}</code>, or <code>{{Comment}}</code> <a href="#concept-node">node</a>:
 
   <p class="note">Note: In this case, <var>last partially contained child</var> is <var>original end node</var>.
 
@@ -648,7 +648,7 @@ interface Range {
 
    <li><p>Set the <a>data</a> of <var>clone</var> to the result of <a>substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
   </ol>
 
  <li>
@@ -657,21 +657,21 @@ interface Range {
   <ol>
    <li><p>Let <var>clone</var> be a <a>clone</a> of <var>last partially contained child</var>.
 
-   <li><p><a>Append</a> <var>clone</var> to <var>fragment</var>.
+   <li><p><a href="#node-append">Append</a> <var>clone</var> to <var>fragment</var>.
 
-   <li><p>Let <var>subrange</var> be a new <a>range</a> whose <a>start</a> is (<var>last partially contained child</var>, 0) and whose <a>end</a> is (<var>original end node</var>, <var>original end offset</var>).
+   <li><p>Let <var>subrange</var> be a new <a href="#concept-range">range</a> whose <a>start</a> is (<var>last partially contained child</var>, 0) and whose <a>end</a> is (<var>original end node</var>, <var>original end offset</var>).
 
    <li><p>Let <var>subfragment</var> be the result of <a href="#concept-range-clone">cloning</a> <var>subrange</var>.
 
-   <li><p><a>Append</a> <var>subfragment</var> to <var>clone</var>.
+   <li><p><a href="#node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
   </ol>
 
  <li><p>Return <var>fragment</var>.
 </ol>
 
-<p>The <dfn><code>cloneContents()</code></dfn> method must return the result of <a href="#concept-range-clone">cloning</a> <a>context object</a>.
+<p>The <dfn method for=Range><code>cloneContents()</code></dfn> method, when invoked, must return the result of <a href="#concept-range-clone">cloning</a> <a>context object</a>.
 
-<p>To <dfn lt="range insert|insert">insert</dfn> a <a>node</a> <var>node</var> into a <a>range</a> <var>range</var>, run these steps:
+<p>To <dfn lt="range insert">insert</dfn> a <a href="#concept-node">node</a> <var>node</var> into a <a href="#concept-range">range</a> <var>range</var>, run these steps:
 
 <ol>
   <!-- Chrome 12 dev throws "HierarchyRequestError" if node is the same
@@ -700,7 +700,7 @@ interface Range {
  -->
  <li><p>Let <var>referenceNode</var> be null.
 
- <li><p>If <var>range</var>'s <a>start node</a> is a <code><a>Text</a></code> <a>node</a>, set <var>referenceNode</var> to that <code><a>Text</a></code> <a>node</a>. <!-- This will change when we split it. -->
+ <li><p>If <var>range</var>'s <a>start node</a> is a <code>{{Text}}</code> <a href="#concept-node">node</a>, set <var>referenceNode</var> to that <code>{{Text}}</code> <a href="#concept-node">node</a>. <!-- This will change when we split it. -->
 
  <li><p>Otherwise, set <var>referenceNode</var> to the <a>child</a> of <a>start node</a> whose <a>index</a> is <a>start offset</a>, and null if there is no such <a>child</a>.
 
@@ -716,12 +716,12 @@ interface Range {
  with what all other browsers do. -->
  <li><p><a>Ensure pre-insertion validity</a>of <var>node</var> into <var>parent</var> before <var>referenceNode</var>.
 
- <li><p>If <var>range</var>'s <a>start node</a> is a <code><a>Text</a></code> <a>node</a>, <a>split</a> it with offset <var>range</var>'s <a>start offset</a>, set <var>referenceNode</var> to the result, and set <var>parent</var> to <var>referenceNode</var>'s <a>parent</a>.
+ <li><p>If <var>range</var>'s <a>start node</a> is a <code>{{Text}}</code> <a href="#concept-node">node</a>, <a>split</a> it with offset <var>range</var>'s <a>start offset</a>, set <var>referenceNode</var> to the result, and set <var>parent</var> to <var>referenceNode</var>'s <a>parent</a>.
 
  <li><p>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its <a>next sibling</a>. <!-- Because we're
  about to remove node from its parent. -->
 
- <li><p>If <var>node</var>'s <a>parent</a> is not null, <a>remove</a> <var>node</var> from its <a>parent</a>.
+ <li><p>If <var>node</var>'s <a>parent</a> is not null, <a href="#node-remove">remove</a> <var>node</var> from its <a>parent</a>.
 
  <!-- Browsers disagree on how to handle the case where the range is
  collapsed: do you increment the end offset so the node is now included, or
@@ -746,16 +746,16 @@ interface Range {
  -->
  <li><p>Let <var>newOffset</var> be <var>parent</var>'s <a>length</a> if <var>referenceNode</var> is null, and <var>referenceNode</var>'s <a>index</a> otherwise.
 
- <li><p>Increase <var>newOffset</var> by <var>node</var>'s <a>length</a> if <var>node</var> is a <code><a>DocumentFragment</a></code> <a>node</a>, and one otherwise.
+ <li><p>Increase <var>newOffset</var> by <var>node</var>'s <a>length</a> if <var>node</var> is a <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, and one otherwise.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before <var>referenceNode</var>.
 
  <li><p>If <var>range</var>'s <a>start</a> and <a>end</a> are the same, set <var>range</var>'s <a>end</a> to (<var>parent</var>, <var>newOffset</var>).
 </ol>
 
-<p>The <dfn><code>insertNode(<var>node</var>)</code></dfn> method must <a>insert</a> <var>node</var> into <a>context object</a>.
+<p>The <dfn method for=Range><code>insertNode(<var>node</var>)</code></dfn> method, when invoked, must <a>range insert</a> <var>node</var> into <a>context object</a>.
 
-<p>The <dfn><code>surroundContents(<var>newParent</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>surroundContents(<var>newParent</var>)</code></dfn> method, when invoked, must run these steps:
 
 <!--
 IE9 and Chrome 12 dev throw exceptions before doing any DOM mutations in at
@@ -769,13 +769,13 @@ check first thing, which matches everyone but Firefox.
 -->
 
 <ol>
- <li><p>If a non-<code><a>Text</a></code> <a>node</a> is <a>partially contained</a> in the <a>context object</a>, <a>throw</a> an "<code><a>InvalidStateError</a></code>". [[!WEBIDL]]
+ <li><p>If a non-<code>{{Text}}</code> <a href="#concept-node">node</a> is <a>partially contained</a> in the <a>context object</a>, <a>throw</a> an "<code><a>InvalidStateError</a></code>". [[!WEBIDL]]
  <!-- Makes some sense: otherwise we'd clone a bunch of containers, which is
  unexpected. -->
  <!-- XXX Could we rephrase this condition to be more algorithmic and less
  declarative?-->
 
- <li><p>If <var>newParent</var> is a <code><a>Document</a></code>, <code><a>DocumentType</a></code>, or <code><a>DocumentFragment</a></code> <a>node</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
+ <li><p>If <var>newParent</var> is a <code>{{Document}}</code>, <code>{{DocumentType}}</code>, or <code>{{DocumentFragment}}</code> <a href="#concept-node">node</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
  <!-- But for Comment, Text, and ProcessingInstruction, we just fall through
  and throw a HIERARCHY_REQUEST_ERR when we try appendChild(). This makes
  absolutely no sense, but it's what DOM 2 Range specifies, and it's what
@@ -805,9 +805,9 @@ check first thing, which matches everyone but Firefox.
 
  <li><p>If <var>newParent</var> has <a>children</a>, <a>replace all</a> with null within <var>newParent</var>.
 
- <li><p><a>Insert</a> <var>newParent</var> into <a>context object</a>.
+ <li><p><a>Range insert</a> <var>newParent</var> into <a>context object</a>.
 
- <li><p><a>Append</a> <var>fragment</var> to <var>newParent</var>.
+ <li><p><a href="#node-append">Append</a> <var>fragment</var> to <var>newParent</var>.
 
  <li><p><a>Select</a> <var>newParent</var> within <a>context object</a>.
  <!-- Generally this isn't needed, because insertNode() will already do it,
@@ -815,25 +815,25 @@ check first thing, which matches everyone but Firefox.
  range lies in a single text node). -->
 </ol>
 
-<p>The <dfn><code>cloneRange()</code></dfn> method must return a new <a>range</a> with the same <a>start</a> and <a>end</a> as the <a>context object</a>.
+<p>The <dfn method for=Range><code>cloneRange()</code></dfn> method, when invoked, must return a new <a href="#concept-range">range</a> with the same <a>start</a> and <a>end</a> as the <a>context object</a>.
 
-<p>The <dfn id="range-detach-func" for="range"><code>detach()</code></dfn> method must do nothing. <span class="note">Note: Its functionality (disabling a <code><a>Range</a></code> object) was removed, but the method itself is preserved for compatibility.</span>
+<p>The <dfn method for=Range id="range-detach-func"><code>detach()</code></dfn> method, when invoked, must do nothing. <span class="note">Note: Its functionality (disabling a <code><a href="#concept-range">Range</a></code> object) was removed, but the method itself is preserved for compatibility.</span>
 
 <hr>
 
 <dl>
- <dt><var>position</var> = <var>range</var> . <code><a>comparePoint</a></code>( <var>parent</var>, <var>offset</var> )
+ <dt><var ignore>position</var> = <var>range</var> . {{Range/comparePoint(node, offset)}}
  <dd><p>Returns −1 if the point is before the range, 0 if the point is
  in the range, and 1 if the point is after the range.
 
- <dt><var>intersects</var> = <var>range</var> . <code><a>intersectsNode</a></code>( <var>node</var> )
+ <dt><var ignore>intersects</var> = <var>range</var> . {{Range/intersectsNode(node)}}
  <dd><p>Returns whether <var>range</var> intersects
  <var>node</var>.
 </dl>
 
 <div>
 
-<p>The <dfn><code>isPointInRange(<var>node</var>, <var>offset</var>)</code></dfn> must run these steps:
+<p>The <dfn method for=Range><code>isPointInRange(<var>node</var>, <var>offset</var>)</code></dfn> method, when invoked, must run these steps:
 <!-- Tested October 2011 on Firefox 9.0a2 and Chrome 16 dev.  IE9 and Opera
 11.50 don't support the method. -->
 
@@ -842,7 +842,7 @@ check first thing, which matches everyone but Firefox.
  <!-- This happens even if the offset is negative or too large, or if the node
  is a doctype, in both Firefox 9.0a2 and Chrome 16 dev. -->
 
- <li><p>If <var>node</var> is a <a>doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
+ <li><p>If <var>node</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
 
  <li><p>If (<var>node</var>, <var>offset</var>) is <a>before</a> <a>start</a> or <a>after</a> <a>end</a>, return false.
 
@@ -850,7 +850,7 @@ check first thing, which matches everyone but Firefox.
 </ol>
 
 
-<p>The <dfn><code>comparePoint(<var>node</var>, <var>offset</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>comparePoint(<var>node</var>, <var>offset</var>)</code></dfn> method, when invoked, must run these steps:
 <!-- IE9 doesn't support this method at all.  Firefox 12.0a1, Chrome 17 dev,
 and Opera Next 12.00 alpha all do. -->
 
@@ -859,7 +859,7 @@ and Opera Next 12.00 alpha all do. -->
  <!-- Opera Next 12.00 alpha seems to return -1 in this case.  The spec matches
  Firefox 12.0a1 and Chrome 17 dev. -->
 
- <li><p>If <var>node</var> is a <a>doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
+ <li><p>If <var>node</var> is a <a href="#concept-doctype">doctype</a>, <a>throw</a> an "<code>InvalidNodeTypeError</code>". [[!WEBIDL]]
  <!-- This matches Chrome 17 dev instead of Firefox 12.0a1 and Opera Next 12.00 alpha, which don't throw and seem to just ignore the offset instead.  See
  comment for isPointInRange(). -->
 
@@ -876,7 +876,7 @@ and Opera Next 12.00 alpha all do. -->
 
 <hr>
 
-<p>The <dfn><code>intersectsNode(<var>node</var>)</code></dfn> method must run these steps:
+<p>The <dfn method for=Range><code>intersectsNode(<var>node</var>)</code></dfn> method, when invoked, must run these steps:
 <!-- Supported by Chrome 17 dev and Opera Next 12.00 alpha, but not IE9 or
 Firefox 12.0a1. -->
 
@@ -903,24 +903,24 @@ Firefox 12.0a1. -->
 
 <hr>
 
-<p>The <dfn id="range-stringifier">stringifier</dfn> must run these steps:
+<p>The <dfn export for=Range id="range-stringifier">stringifier</dfn> must run these steps:
 
 <ol>
  <li><p>Let <var>s</var> be the empty string.
 
- <li><p>If <a>start node</a> is <a>end node</a>, and it is a <code><a>Text</a></code> <a>node</a>, return the substring of that <code><a>Text</a></code> <a>node</a>'s <a>data</a> beginning at <a>start offset</a> and ending at <a>end offset</a>.
+ <li><p>If <a>start node</a> is <a>end node</a>, and it is a <code>{{Text}}</code> <a href="#concept-node">node</a>, return the substring of that <code>{{Text}}</code> <a href="#concept-node">node</a>'s <a>data</a> beginning at <a>start offset</a> and ending at <a>end offset</a>.
 
- <li><p>If <a>start node</a> is a <code><a>Text</a></code> <a>node</a>, append to <var>s</var> the substring of that <a>node</a>'s <a>data</a> from the <a>start offset</a> until the end.
+ <li><p>If <a>start node</a> is a <code>{{Text}}</code> <a href="#concept-node">node</a>, append to <var>s</var> the substring of that <a href="#concept-node">node</a>'s <a>data</a> from the <a>start offset</a> until the end.
 
- <li><p>Append to <var>s</var> the concatenation, in <a>tree order</a>, of the <a>data</a> of all <code><a>Text</a></code> <a>nodes</a> that are <a>contained</a> in the <a>context object</a>.
+ <li><p>Append to <var>s</var> the concatenation, in <a>tree order</a>, of the <a>data</a> of all <code>{{Text}}</code> <a>nodes</a> that are <a>contained</a> in the <a>context object</a>.
 
- <li><p>If <a>end node</a> is a <code><a>node</a></code>, append to <var>s</var> the substring of that <a>node</a>'s <a>data</a> from its start until the <a>end offset</a>.
+ <li><p>If <a>end node</a> is a <code><a href="#concept-node">node</a></code>, append to <var>s</var> the substring of that <a href="#concept-node">node</a>'s <a>data</a> from its start until the <a>end offset</a>.
 
  <li><p>Return <var>s</var>.
 </ol>
 
 <hr>
 
-<p class="note">Note: The <code><a href="http://www.w3.org/TR/DOM-Parsing/#widl-Range-createContextualFragment-DocumentFragment-DOMString-fragment">createContextualFragment()</a></code>, <code><a href="https://www.w3.org/TR/cssom-view-1/#dom-element-getclientrects">getClientRects()</a></code>, and <code><a href="https://www.w3.org/TR/cssom-view-1/#dom-element-getboundingclientrect">getBoundingClientRect()</a></code> methods are defined in other specifications.[[DOM-PARSING]][[CSSOM-VIEW-1]]
+<p class="note">Note: The <code><a>createContextualFragment</a>()</code>, <code><a>getClientRects</a>()</code>, and <code><a>getBoundingClientRect</a>()</code> methods are defined in other specifications.[[DOM-PARSING]][[CSSOM-VIEW-1]]
 
 </section>

--- a/sections/sets.include
+++ b/sections/sets.include
@@ -1,36 +1,40 @@
 <section>
 <h2 id="sets">Sets</h2>
 
-<p class="note">Note: Yes, the name <code><a>DOMTokenList</a></code> is unfortunate legacy mishap.
+<p class="note">Note: Yes, the name <code>{{DOMTokenList}}</code> is unfortunate legacy mishap.
 
 
-<h3 id="sets-interface-domtokenlist">Interface <code><a>DOMTokenList</a></code></h3>
+<h3 id="sets-interface-domtokenlist">Interface <code>{{DOMTokenList}}</code></h3>
 
 <pre class='idl'>
 interface DOMTokenList {
   readonly attribute unsigned long length;
   getter DOMString? item(unsigned long index);
   boolean contains(DOMString token);
+
   void add(DOMString... tokens);
   void remove(DOMString... tokens);
+
   boolean toggle(DOMString token, optional boolean force);
   void replace(DOMString token, DOMString newToken);
+
   boolean supports(DOMString token);
+
   stringifier attribute DOMString value;
-  iterable<DOMString>;
+  iterable&lt;DOMString>;
 };
 </pre>
 
-<p>A <code><a>DOMTokenList</a></code> object has an associated of <dfn>token set</dfn> (an <a>ordered set</a>), which is initially empty.
+<p>A <code>{{DOMTokenList}}</code> object has an associated of <dfn>token set</dfn> (an <a>ordered set</a>), which is initially empty.
 
-<p>A <code><a>DOMTokenList</a></code> object also has an associated <a>element</a> and an <a>attribute</a>'s <a>local name</a>.
+<p>A <code>{{DOMTokenList}}</code> object also has an associated <a href="#concept-element">element</a> and an <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a>.
 
-<p>Specifications may define <dfn>supported tokens</dfn> for a <code><a>DOMTokenList</a></code>'s associated <a>attribute</a>'s <a>local name</a>.
+<p><a>Specifications</a> may define <dfn>supported tokens</dfn> for a <code>{{DOMTokenList}}</code>'s associated <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a>.
 
-<p>A <code><a>DOMTokenList</a></code> object's <dfn>validation steps</dfn> for a given <var>token</var> are:
+<p>A <code>{{DOMTokenList}}</code> object's <dfn>validation steps</dfn> for a given <var>token</var> are:
 
 <ol>
- <li>If the associated <a>attribute</a>'s <a>local name</a> does not define <a>supported tokens</a>, then <a>throw</a> a "<code><a>TypeError</a></code>".
+ <li>If the associated <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a> does not define <a>supported tokens</a>, then <a>throw</a> a "<code><a>TypeError</a></code>".
 
  <li>Let <var>lowercase token</var> be a copy of <var>token</var>, in <a>ASCII lowercase</a>.
 
@@ -39,49 +43,54 @@ interface DOMTokenList {
  <li>Return false.
 </ol>
 
-<p>A <code><a>DOMTokenList</a></code> object's <dfn>update steps</dfn> are to <a>set an attribute value</a> for the associated <a>element</a> using associated <a>attribute</a>'s <a>local name</a> and the result of running the <a>ordered set serializer</a> for <a>token set</a>.
+<p>A <code>{{DOMTokenList}}</code> object's <dfn>update steps</dfn> are to <a>set an attribute value</a> for the associated <a href="#concept-element">element</a> using associated <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a> and the result of running the <a>ordered set serializer</a> for <a>token set</a>.
 
-<p>A <code><a>DOMTokenList</a></code> object's <dfn>serialize steps</dfn> are to return the result of running <a>get an attribute value</a> given the associated <a>element</a> and the associated <a>attribute</a>'s <a>local name</a>.
+<p>A <code>{{DOMTokenList}}</code> object's <dfn>serialize steps</dfn> are to return the result of running <a>get an attribute value</a> given the associated <a href="#concept-element">element</a> and the associated <a href="#concept-attribute">attribute</a>'s <a href="#attribute-local-name">local name</a>.
 
 <dl>
- <dt><code><var>tokenlist</var> . <a href="#domtokenlist-length">length</a></code> <dd><p>Returns the number of tokens.
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/length}}</code>
+ <dd>
+  <p>Returns the number of tokens.
 
- <dt><code><var>tokenlist</var> . <a>item</a>(<var>index</var>)</code> <dt><code><var>tokenlist</var>[<var>index</var>]</code> <dd><p>Returns the token with index <var>index</var>.
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/item(index)}}</code>
+ <dt><code><var>tokenlist</var>[<var>index</var>]</code>
+ <dd>
+  <p>Returns the token with index <var>index</var>.
 
- <dt><code><var>tokenlist</var> . <a>contains</a>(<var>token</var>)</code>
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/contains(token)}}</code>
  <dd>
   <p>Returns true if <var>token</var> is present, and false otherwise.
 
- <dt><code><var>tokenlist</var> . <a>add</a>(<var>tokens</var>…)</code>
+ <dt><code><var>tokenlist</var> . <a for=DOMTokenList lt="add()">add(<var>tokens</var>&hellip;)</a></code>
  <dd>
   <p>Adds all arguments passed, except those already present.
   <p>Throws a "<code><a>SyntaxError</a></code>" if one of the arguments is the empty string.
   <p>Throws an "<code><a>InvalidCharacterError</a></code>" if one of the arguments contains any <a>ASCII whitespace</a>.
 
- <dt><code><var>tokenlist</var> . <a>remove</a>(<var>tokens</var>…)</code>
+ <dt><code><var>tokenlist</var> . <a for=DOMTokenList lt="remove()">remove(<var>tokens</var>&hellip;)</a></code>
  <dd>
   <p>Removes arguments passed, if they are present.
   <p>Throws a "<code><a>SyntaxError</a></code>" if one of the arguments is the empty string.
   <p>Throws an "<code><a>InvalidCharacterError</a></code>" if one of the arguments contains any <a>ASCII whitespace</a>.
 
- <dt><code><var>tokenlist</var> . <a>toggle</a>(<var>token</var> [, <var>force</var>])</code>
+ <dt><code><var>tokenlist</var> . <a method for=DOMTokenList lt="toggle()">toggle(<var>token</var> [, <var>force</var>])</a></code>
  <dd>
   <p>If <var>force</var> is not given, "toggles" <var>token</var>, removing it if it's present and adding it if it's not. If <var>force</var> is true, adds <var>token</var> (same as <code><a>add()</a></code>).  If <var>force</var> is false, removes <var>token</var> (same as <code><a>remove()</a></code>). <p>Returns true if <var>token</var> is now present, and false otherwise.
   <p>Throws a "<code><a>SyntaxError</a></code>" if <var>token</var> is empty.
   <p>Throws an "<code><a>InvalidCharacterError</a></code>" if <var>token</var> contains any spaces.
 
- <dt><code><var>tokenlist</var> . <a>replace</a>(<var>token</var>, <var>newToken</var>)</code>
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/replace(token, newToken)}}</code>
  <dd>
   <p>Replaces <var>token</var> with <var>newToken</var>.
   <p>Throws a "<code><a>SyntaxError</a></code>" if one of the arguments is the empty string.
   <p>Throws an "<code><a>InvalidCharacterError</a></code>" if one of the arguments contains any <a>ASCII whitespace</a>.
 
- <dt><code><var>tokenlist</var> . <a>supports</a>(<var>token</var>)</code>
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/supports(token)}}</code>
  <dd>
   <p>Returns true if <var>token</var> is in the associated attribute’s supported tokens. Returns false otherwise.
   <p>Throws a "<code><a>TypeError</a></code>" if the associated attribute has no supported tokens defined.
 
- <dt><code><var>tokenlist</var> . <a href="#domtokenlist-value">value</a></code>
+ <dt><code><var>tokenlist</var> . {{DOMTokenList/value}}</code>
  <dd>
   <p>Returns the associated set as string.
   <p>Can be set, to change the associated set.
@@ -89,11 +98,11 @@ interface DOMTokenList {
 
 <div>
 
-<p>The <dfn id="domtokenlist-length" for="domtokenlist"><code>length</code></dfn> attribute' getter must return the number of tokens in the <a>token set</a>.
+<p>The <dfn attribute id="domtokenlist-length" for=DOMTokenList><code>length</code></dfn> attribute's getter must return the number of tokens in the <a>token set</a>.
 
 <p>The object's <a>supported property indices</a> are the numbers in the range zero to the number of tokens in <a>token set</a> minus one, unless <a>token set</a> is  empty, in which case there are no <a>supported property indices</a>.
 
-<p>The <dfn id="domtokenlist-item" for="domtokenlist"><code>item(<var>index</var>)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=DOMTokenList id="domtokenlist-item"><code>item(<var>index</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>index</var> is equal to or greater than the number of tokens in <a>token set</a>, then return null.
@@ -101,11 +110,10 @@ interface DOMTokenList {
  <li><p>Return the <var>index</var>th token in <a>token set</a>.
 </ol>
 
-<p>The
-<dfn id="set-contains-func" for="set"><code>contains(<var>token</var>)</code></dfn> method, when invoked, must return true if <var>token</var> is in <a>token set</a>,
+<p>The <dfn method for=DOMTokenList id="set-contains-func"><code>contains(<var>token</var>)</code></dfn> method, when invoked, must return true if <var>token</var> is in <a>token set</a>,
 and false otherwise.
 
-<p>The <dfn><code>add(<var>tokens</var>…)</code></dfn> method, when invoked, must run these steps:
+<p>The <dfn method for=DOMTokenList><code>add(<var>tokens</var>&hellip;)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>For each <var>token</var> in <var>tokens</var>:
@@ -121,8 +129,7 @@ and false otherwise.
  <li><p>Run the <a>update steps</a>.
 </ol>
 
-<p>The <dfn id="set-remove-func" for="set"><code>remove(<var>tokens</var>…)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn method for=DOMTokenList id="set-remove-func"><code>remove(<var>tokens</var>&hellip;)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>For each <var>token</var> in <var>tokens</var>:
@@ -138,8 +145,7 @@ method, when invoked, must run these steps:
  <li><p>Run the <a>update steps</a>.
 </ol>
 
-<p>The <dfn><code>toggle(<var>token</var>, <var>force</var>)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn method for=DOMTokenList><code>toggle(<var>token</var>, <var>force</var>)</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>If <var>token</var> is the empty string, then <a>throw</a> a "<code><a>SyntaxError</a></code>".
@@ -165,7 +171,7 @@ method, when invoked, must run these steps:
  <li>Return <var>result</var>.
 </ol>
 
-<p>The <dfn id="set-replace-func" for="set"><code>replace(<var>token</var>, <var>newToken</var>)</code></dfn>
+<p>The <dfn method for=DOMTokenList id="set-replace-func"><code>replace(<var>token</var>, <var>newToken</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
@@ -178,12 +184,12 @@ method, when invoked, must run these steps:
  <li><p>Run the <a>update steps</a>.
 </ol>
 
-<p>The <dfn id="set-supports-func" for="set"><code>supports(<var>token</var>)</code></dfn>
+<p>The <dfn method for=DOMTokenList id="set-supports-func"><code>supports(<var>token</var>)</code></dfn>
 method, when invoked, must return the result of running <a>validation steps</a> for the given <var>token</var>.
 
-<p>The <dfn id="domtokenlist-value"><code>value</code></dfn> attribute must return the result of running <a>serialize steps</a> for <a>token set</a>.
+<p>The <dfn attribute for=DOMTokenList id="domtokenlist-value"><code>value</code></dfn> attribute's getter must return the result of running <a>serialize steps</a> for <a>token set</a>.
 
-<p>Setting the <code><a href="#domtokenlist-value">value</a></code> attribute must run the <a>ordered set parser</a> for the given value and set <a>token set</a> to the result.
+<p>Setting the {{DOMTokenList/value}} attribute must run the <a>ordered set parser</a> for the given value and set <a>token set</a> to the result.
 
 </div>
 

--- a/sections/terminology.include
+++ b/sections/terminology.include
@@ -27,7 +27,7 @@ or null, and an ordered list of zero or more
 <var>B</var>, if either <var>A</var> is a
 <a>child</a> of <var>B</var> or
 <var>A</var> is a <a>child</a> of an
-object <var>C</var> that is a
+object <var ignore>C</var> that is a
 <a>descendant</a> of <var>B</var>.
 
 <p>An
@@ -49,7 +49,7 @@ an object or one of its <a>ancestors</a>.
 share the same non-null <a>parent</a>.
 
 <p>An object <var>A</var> is
-<dfn>preceding</dfn> an object
+<dfn lt="preceding | precedes">preceding</dfn> an object
 <var>B</var> if <var>A</var> and <var>B</var> are in the
 same <a>tree</a> and <var>A</var> comes
 before <var>B</var> in
@@ -171,11 +171,11 @@ To <dfn export>validate</dfn> a <var>qualifiedName</var>, run these steps:
 
 <ol>
  <li><p>If <var>qualifiedName</var> does not match the <code class="external" data-anolis-spec="xmlns">
- <a href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production,
+ <a type>Name</a></code> production,
  then <a>throw</a> an {{InvalidCharacterError}}.
 
  <li><p>If <var>qualifiedName</var> does not match the <code class="external" data-anolis-spec="xmlns">
- <a>QName</a></code> production, then <a>throw</a> a {{NamespaceError}}.
+ <a type>QName</a></code> production, then <a>throw</a> a {{NamespaceError}}.
 </ol>
 
 To <dfn export>validate and extract</dfn> a <var>namespace</var> and <var>qualifiedName</var>,

--- a/sections/traversal.include
+++ b/sections/traversal.include
@@ -1,14 +1,14 @@
 <section>
 <h2 id="traversal">Traversal</h2>
 
-<code><a>NodeIterator</a></code> and <code><a>TreeWalker</a></code> objects can be used to filter and traverse <a>node</a> <a>trees</a>.
+<code>{{NodeIterator}}</code> and <code>{{TreeWalker}}</code> objects can be used to filter and traverse <a href="#concept-node">node</a> <a>trees</a>.
 
-Each <code><a>NodeIterator</a></code> and <code><a>TreeWalker</a></code> object also has an associated <dfn id="traversal-root" for="traversal">root</dfn> <a>node</a>, <dfn id="traversal-whattoshow" for="traversal">whatToShow</dfn> bitmask, and <dfn id="traversal-filter" for="traversal">filter</dfn> callback.
+Each <code>{{NodeIterator}}</code> and <code>{{TreeWalker}}</code> object also has an associated <dfn id="traversal-root" for="traversal">root</dfn> <a href="#concept-node">node</a>, <dfn id="traversal-whattoshow" for="traversal">whatToShow</dfn> bitmask, and <dfn id="traversal-filter" for="traversal">filter</dfn> callback.
 
 To <dfn dfn id="node-filter" for="node">filter</dfn> <var>node</var> run these steps:
 
 <ol>
-  1. Let <var>n</var> be <var>node</var>'s <code><a>nodeType</a></code> attribute value minus 1. 
+  1. Let <var>n</var> be <var>node</var>'s <code>{{Node/nodeType}}</code> attribute value minus 1. 
 
   2. If the <var>n</var><sup>th</sup> bit (where 0 is the least significant bit) of <a href="#traversal-whattoshow">whatToShow</a> is not set, return <code><a>FILTER_SKIP</a></code>.
 
@@ -20,7 +20,7 @@ To <dfn dfn id="node-filter" for="node">filter</dfn> <var>node</var> run these s
 
 </ol>
 
-<h3 id="traversal-interface-nodeiterator">Interface <code><a>NodeIterator</a></code></h3>
+<h3 id="traversal-interface-nodeiterator">Interface <code>{{NodeIterator}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -38,11 +38,11 @@ interface NodeIterator {
 };
 </pre>
 
-<p class="note">Note: <code><a>NodeIterator</a></code> objects can be created using the <code><a>createNodeIterator()</a></code> method.
+<p class="note">Note: <code>{{NodeIterator}}</code> objects can be created using the <code><a>createNodeIterator()</a></code> method.
 
-<p>Each <code><a>NodeIterator</a></code> object has an associated <dfn>iterator collection</dfn>, which is a <a>collection</a> rooted at <a href="#traversal-root">root</a>, whose filter matches any <a>node</a>.
+<p>Each <code>{{NodeIterator}}</code> object has an associated <dfn>iterator collection</dfn>, which is a <a>collection</a> rooted at <a href="#traversal-root">root</a>, whose filter matches any <a href="#concept-node">node</a>.
 
-<p class="note">Note: As mentioned earlier <code><a>NodeIterator</a></code> objects have an associated <a href="#traversal-root">root</a> <a>node</a>, <a href="#traversal-whattoshow">whatToShow</a> bitmask, and <a href="#traversal-filter">filter</a> callback as well.
+<p class="note">Note: As mentioned earlier <code>{{NodeIterator}}</code> objects have an associated <a href="#traversal-root">root</a> <a href="#concept-node">node</a>, <a href="#traversal-whattoshow">whatToShow</a> bitmask, and <a href="#traversal-filter">filter</a> callback as well.
 
 The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIterator</var> and <var>toBeRemovedNode</var>, are as followings:
 
@@ -55,9 +55,9 @@ The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIte
 
   <ol>
    <li><p>Let <var>next</var> be <var>toBeRemovedNode</var>'s first <a>following</a>
-   <a>node</a> that is an <a>inclusive descendant</a> of <var>nodeIterator</var>'s
+   <a href="#concept-node">node</a> that is an <a>inclusive descendant</a> of <var>nodeIterator</var>'s
    <a for=traversal>root</a> and is not an <a>inclusive descendant</a> of
-   <var>toBeRemovedNode</var>, and null if there is no such <a>node</a>.
+   <var>toBeRemovedNode</var>, and null if there is no such <a href="#concept-node">node</a>.
 
    <li><p>If <var>next</var> is non-null, then set <var>nodeIterator</var>'s
    {{NodeIterator/referenceNode}} attribute to <var>next</var> and return.
@@ -78,20 +78,20 @@ The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIte
 
 <hr>
 
-<p>The <dfn attribute id="iterator-root" for="iterator"><code>root</code></dfn> attribute must return <a href="#traversal-root">root</a>.</p>
+<p>The <dfn attribute id="iterator-root" for=NodeIterator><code>root</code></dfn> attribute's getter must return <a href="#traversal-root">root</a>.</p>
 
-<p>The <dfn><code>referenceNode</code></dfn> and <dfn><code>pointerBeforeReferenceNode</code></dfn> attributes must return what they were initialized to.</p>
+<p>The <dfn attribute for=NodeIterator><code>referenceNode</code></dfn> and <dfn attribute for=NodeIterator><code>pointerBeforeReferenceNode</code></dfn> attributes must return what they were initialized to.</p>
 
-<p>The <dfn attribute id="iterator-whattoshow" for="iterator"><code>whatToShow</code></dfn> attribute must return <a href="#traversal-whattoshow">whatToShow</a>.
+<p>The <dfn attribute id="iterator-whattoshow" for=NodeIterator><code>whatToShow</code></dfn> attribute's getter must return <a href="#traversal-whattoshow">whatToShow</a>.
 
-<p>The <dfn attribute id="iterator-filter" for="iterator"><code>filter</code></dfn> attribute must return <a href="#traversal-filter">filter</a>.
+<p>The <dfn attribute id="iterator-filter" for=NodeIterator><code>filter</code></dfn> attribute's getter must return <a href="#traversal-filter">filter</a>.
 
-<p>To <dfn attribute id="iterator-traverse" for="iterator">traverse</dfn> in direction <var>direction</var> run these steps:
+<p>To <dfn attribute id="iterator-traverse" for=NodeIterator>traverse</dfn> in direction <var ignore>direction</var> run these steps:
 
 <ol>
- <li><p>Let <var>node</var> be the value of the <code><a>referenceNode</a></code> attribute.
+ <li><p>Let <var>node</var> be the value of the <code>{{NodeIterator/referenceNode}}</code> attribute.
 
- <li><p>Let <var>before node</var> be the value of the <code><a>pointerBeforeReferenceNode</a></code> attribute.
+ <li><p>Let <var>before node</var> be the value of the <code>{{NodeIterator/pointerBeforeReferenceNode}}</code> attribute.
 
  <li>
   <p>Run these substeps:
@@ -100,12 +100,12 @@ The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIte
     <dl class="switch">
      <dt>If direction is next</dt>
      <dd>
-      <p>If <var>before node</var> is false, let <var>node</var> be the first <a>node</a> <a>following</a> <var>node</var> in the <a>iterator collection</a>. If there is no such <a>node</a> return null.
+      <p>If <var>before node</var> is false, let <var>node</var> be the first <a href="#concept-node">node</a> <a>following</a> <var>node</var> in the <a>iterator collection</a>. If there is no such <a href="#concept-node">node</a> return null.
       <p>If <var>before node</var> is true, set it to false.
      <dt>If direction is previous</dt>
      <dd>
       <p>If <var>before node</var> is true, let <var>node</var>
-      be the first <a>node</a> <a>preceding</a> <var>node</var> in the <a>iterator collection</a>. If there is no such <a>node</a> return null.
+      be the first <a href="#concept-node">node</a> <a>preceding</a> <var>node</var> in the <a>iterator collection</a>. If there is no such <a href="#concept-node">node</a> return null.
       <p>If <var>before node</var> is false, set it to true.
     </dl>
    <li><p><a href="#node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return value.
@@ -114,16 +114,16 @@ The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIte
     next step in the overall set of steps.
     <p>Otherwise, run these substeps again.
   </ol>
- <li><p>Set the <code><a>referenceNode</a></code> attribute to <var>node</var>, set the <code><a>pointerBeforeReferenceNode</a></code> attribute to <var>before node</var>, and return <var>node</var>.
+ <li><p>Set the <code>{{NodeIterator/referenceNode}}</code> attribute to <var>node</var>, set the <code>{{NodeIterator/pointerBeforeReferenceNode}}</code> attribute to <var>before node</var>, and return <var>node</var>.
 </ol>
 
-<p>The <dfn id="nodeiterator-nextnode-func" for="nodeiterator"><code>nextNode()</code></dfn> method must <a>traverse</a> in direction next.
+<p>The <dfn method id="nodeiterator-nextnode-func" for=NodeIterator><code>nextNode()</code></dfn> method, when invoked, must <a>traverse</a> in direction next.
 
-<p>The <dfn id="nodeiterator-previousnode-func" for="nodeiterator"><code>previousNode()</code></dfn> method must <a>traverse</a> in direction previous.
+<p>The <dfn method id="nodeiterator-previousnode-func" for=NodeIterator><code>previousNode()</code></dfn> method, when invoked, must <a>traverse</a> in direction previous.
 
-<p>The <dfn id="traversal-detach-func" for="traversal"><code>detach()</code></dfn> method must do nothing. <span class="note">Note: Its functionality (disabling a <code><a>NodeIterator</a></code> object) was removed, but the method itself is preserved for compatibility.</span>
+<p>The <dfn method id="traversal-detach-func" for=NodeIterator><code>detach()</code></dfn> method, when invoked, must do nothing. <span class="note">Note: Its functionality (disabling a <code>{{NodeIterator}}</code> object) was removed, but the method itself is preserved for compatibility.</span>
 
-<h3 id="traversal-interface-treewalker">Interface <code><a>TreeWalker</a></code></h3>
+<h3 id="traversal-interface-treewalker">Interface <code>{{TreeWalker}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -143,22 +143,22 @@ interface TreeWalker {
 };
 </pre>
 
-<p class="note">Note: <code><a>TreeWalker</a></code> objects can be created using the <code><a>createTreeWalker()</a></code> method.
+<p class="note">Note: <code>{{TreeWalker}}</code> objects can be created using the <code><a>createTreeWalker()</a></code> method.
 
-<p class="note">Note: As mentioned earlier <code><a>TreeWalker</a></code> objects have an associated <a href="#traversal-root">root</a> <a>node</a>, <a href="#traversal-whattoshow">whatToShow</a> bitmask, and <a href="#traversal-filter">filter</a> callback.
+<p class="note">Note: As mentioned earlier <code>{{TreeWalker}}</code> objects have an associated <a href="#traversal-root">root</a> <a href="#concept-node">node</a>, <a href="#traversal-whattoshow">whatToShow</a> bitmask, and <a href="#traversal-filter">filter</a> callback.
 
-<p>The <dfn id="treewalker-root" for="treeWalker"><code>root</code></dfn> attribute must return <a href="#traversal-root">root</a>.</p>
+<p>The <dfn attribute id="treewalker-root" for=TreeWalker><code>root</code></dfn> attribute's getter must return <a href="#traversal-root">root</a>.</p>
 
-<p>The <dfn id="dom-treewalker-whattoshow" title="dom-TreeWalker-whatToShow"><code>whatToShow</code></dfn> attribute must return <a href="#traversal-whattoshow" title="concept-traversal-whatToShow">whatToShow</a>.
+<p>The <dfn attribute for=TreeWalker id="dom-treewalker-whattoshow" title="dom-TreeWalker-whatToShow"><code>whatToShow</code></dfn> attribute's getter must return <a href="#traversal-whattoshow" title="concept-traversal-whatToShow">whatToShow</a>.
 
-<p>The <dfn id="treewalker-filter"><code>filter</code></dfn> attribute must return <a href="#traversal-filter">filter</a>.
+<p>The <dfn attribute for=TreeWalker id="treewalker-filter"><code>filter</code></dfn> attribute's getter must return <a href="#traversal-filter">filter</a>.
 
-<p>The <dfn id="treewalker-currentnode"><code>currentNode</code></dfn> attribute must return what it was initialized to.</p>
+<p>The <dfn attribute for=TreeWalker id="treewalker-currentnode"><code>currentNode</code></dfn> attribute's getter must return what it was initialized to.</p>
 
-<p>Setting the <code><a href="#treewalker-currentnode">currentNode</a></code> attribute must set it to the new value.</p>
+<p>Setting the <code>{{TreeWalker/currentNode}}</code> attribute must set it to the new value.</p>
 
 
-<p>The <dfn><code>parentNode()</code></dfn> method must run these steps:
+<p>The <dfn method for=TreeWalker><code>parentNode()</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>node</var> be the value of the <code><a href="#treewalker-currentnode">currentNode</a></code> attribute.
@@ -218,9 +218,9 @@ interface TreeWalker {
   </ol>
 </ol>
 
-<p>The <dfn><code>firstChild()</code></dfn> method must <a>traverse children</a> of type first.
+<p>The <dfn method for=TreeWalker><code>firstChild()</code></dfn> method, when invoked, must <a>traverse children</a> of type first.
 
-<p>The <dfn><code>lastChild()</code></dfn> method must <a>traverse children</a> of type last.
+<p>The <dfn method for=TreeWalker><code>lastChild()</code></dfn> method, when invoked, must <a>traverse children</a> of type last.
 
 <p>To <dfn>traverse siblings</dfn> of type <var>type</var> run these steps:
 
@@ -260,11 +260,11 @@ interface TreeWalker {
   </ol>
 </ol>
 
-<p>The <dfn><code>nextSibling()</code></dfn> method must <a>traverse siblings</a> of type next.
+<p>The <dfn method for=TreeWalker><code>nextSibling()</code></dfn> method, when invoked, must <a>traverse siblings</a> of type next.
 
-<p>The <dfn><code>previousSibling()</code></dfn> method must <a>traverse siblings</a> of type previous.
+<p>The <dfn method for=TreeWalker><code>previousSibling()</code></dfn> method, when invoked, must <a>traverse siblings</a> of type previous.
 
-<p>The <dfn id="treewalker-previousnode" for="treewalker"><code>previousNode()</code></dfn> method must run these steps:
+<p>The <dfn method for=TreeWalker><code>previousNode()</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>node</var> be the value of the <code><a href="#treewalker-currentnode">currentNode</a></code> attribute.
@@ -300,7 +300,7 @@ interface TreeWalker {
  <li><p>Return null.
 </ol>
 
-<p>The <dfn id="treewalker-nextnode-func" for="treewalker"><code>nextNode()</code></dfn> method must run these steps:
+<p>The <dfn  method for=TreeWalker id="treewalker-nextnode-func"><code>nextNode()</code></dfn> method, when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>node</var> be the value of the <code><a href="#treewalker-currentnode">currentNode</a></code> attribute.
@@ -323,7 +323,7 @@ interface TreeWalker {
     </ol>
 
    <li>
-    <p>If a <a>node</a> is <a>following</a> <var>node</var> and is not <a>following</a> <a href="#traversal-root">root</a>, set <var>node</var> to the first such <a>node</a>.
+    <p>If a <a href="#concept-node">node</a> is <a>following</a> <var>node</var> and is not <a>following</a> <a href="#traversal-root">root</a>, set <var>node</var> to the first such <a href="#concept-node">node</a>.
     <p>Otherwise, return null.
     <!-- Implemented as iterating over parent/nextSibling -->
 
@@ -335,7 +335,7 @@ interface TreeWalker {
   </ol>
 </ol>
 
-<h3 id="traversal-interface-nodefilter">Interface <code><a>NodeFilter</a></code></h3>
+<h3 id="traversal-interface-nodefilter">Interface <code>{{NodeFilter}}</code></h3>
 
 <pre class='idl'>
 [Exposed=Window]
@@ -364,10 +364,8 @@ callback interface NodeFilter {
 };
 </pre>
 
-<p><code><a>NodeFilter</a></code> objects can be used as
-<a href="#traversal-filter">filter</a> callback and provide
-constants for the <a href="#traversal-whattoshow">whatToShow</a>
-bitmask.
+<p><code>{{NodeFilter}}</code> objects can be used as <a href="#traversal-filter">filter</a> callback and provide
+constants for the <a href="#traversal-whattoshow">whatToShow</a> bitmask.
 
 <p class="note">Note: It is typically implemented as a JavaScript function.
 


### PR DESCRIPTION
Changes for references, formats and grammer issues, like:
1, Move hyperlinks into index.bs.
2, Use HTML5.1 as link reference instead of HTML5.
3, Remove incorrect multiple definitions.
4, Use 'method', 'attribute' for dfn of interface, so that they
can be processed with correct links.
5, Add the description of 'when invoked' for each method of interface.
6, Follow the rule of 'getter' and 'setter' of WebIDL for the attributes
of Interface.
7, Use <a type> for Name, QName and Char instead of copying many
links.
8, So many other fixes for warnings/errors reported by the
'bikeshed' tool.